### PR TITLE
docs: add resolve_all recipe with multiple implementations example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ framework-sized dependency injection container.
   creating service instances.
 - [API reference](./api.md): public methods, exceptions, and import surface.
 - [Release process](./releasing.md): maintainer checklist for versioned releases.
+- [Resolving multiple implementations](./resolve-all.md): use resolve_all() for handlers, plugins, and pipelines.
 
 ## Examples
 

--- a/docs/resolve-all.md
+++ b/docs/resolve-all.md
@@ -1,0 +1,38 @@
+# Resolving Multiple Implementations
+
+Use `resolve_all()` when several implementations of the same interface
+should all run — for example, notification handlers, pipeline steps, or plugins.
+
+## Example: notification handlers
+
+```python
+from injex import Container
+
+class Notifier:
+    def notify(self, message: str) -> None: ...
+
+class EmailNotifier:
+    def notify(self, message: str) -> None:
+        print(f"Email: {message}")
+
+class SlackNotifier:
+    def notify(self, message: str) -> None:
+        print(f"Slack: {message}")
+
+container = Container()
+container.add_singleton(Notifier, EmailNotifier)
+container.add_singleton(Notifier, SlackNotifier)
+
+notifiers = container.resolve_all(Notifier)
+for notifier in notifiers:
+    notifier.notify("Deployment complete")
+```
+
+`resolve_all()` returns every registered implementation in registration order.
+Use it when all handlers should run, not just one.
+
+## When to use resolve_all()
+
+- Fan-out notifications (email, Slack, SMS)
+- Plugin systems where all plugins process an event
+- Pipeline steps that all run in sequence


### PR DESCRIPTION
## Summary

- Added docs/resolve-all.md with a practical recipe showing two implementations 
of one interface resolved with resolve_all(). Covers notification handler 
example and explains when to use resolve_all(). Closes #16

## Checklist

- [x] Tests or docs were added/updated when needed.
- [ ] `uv run ruff format --check .` passes.
- [ ] `uv run ruff check .` passes.
- [ ] `uv run mypy injex tests` passes.
- [ ] `uv run pytest` passes.

## Notes
Fixes #16

Link related issues or design context here.
