### PR TITLE
Actualize async support across docs + bump to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project uses semantic versioning.
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-19
+
 ### Added
 
+- Typed `resolve()` / `resolve_all()` / `aresolve()` via `@overload`: passing a
+  type now infers that type (`resolve(Foo) -> Foo`, `resolve_all(Foo) -> list[Foo]`)
+  instead of `Any`, so resolved services stay type-checked at the call site. A
+  string interface still falls back to `Any`.
+- `aresolve()` on the container raises a clear error when asked to resolve a
+  scoped/transient async resource directly (which it would finalize immediately),
+  pointing at `async with container.ascope()`.
+- Docstrings on the public registration and scope methods.
 - Async resolution, sync-first and still zero-dependency. `await container.aresolve(T)`
   and `async with container.ascope() as scope: await scope.aresolve(T)` await
   `async def` factories and manage async resources: register an async-generator

--- a/README.md
+++ b/README.md
@@ -98,11 +98,33 @@ See the [tutorial](./docs/tutorial.md) for factories, named registrations,
 **When not to:** a handful of constructor calls in one entrypoint is clearer with
 plain manual wiring — reach for Injex when that wiring starts repeating.
 
+## Async
+
+Injex resolves async dependencies too. Register an `async def` factory or an
+async-generator resource and resolve it through `aresolve()` / `ascope()`:
+
+```python
+async def db_session(settings: Settings):  # async-generator resource
+    pool = await open_pool(settings.database_url)
+    try:
+        yield pool
+    finally:
+        await pool.aclose()  # finalized when the scope exits
+
+container.add_scoped_factory(Pool, db_session)
+
+async with container.ascope() as scope:
+    pool = await scope.aresolve(Pool)
+```
+
+Resources are finalized LIFO via the standard library's `AsyncExitStack` (still
+zero runtime deps). The sync `resolve()` raises `AsyncResolutionRequiredException`
+if the graph needs async work, so you never silently get an un-awaited object. See
+[async resolution](./docs/async.md) and the
+[FastAPI example](./examples/fastapi_async.py).
+
 ## Where it doesn't fit (yet)
 
-- **No async resource lifecycle.** Injex resolves objects; it doesn't open/close
-  async resources (`async with`, connection pools) for you. Manage those yourself or
-  with your framework's lifespan.
 - **No provider/config DSL.** If you want a rich configuration-injection system,
   `dependency-injector` is a better fit.
 - **No deep framework auto-wiring.** Injex owns the graph; FastAPI/Typer adapt it at
@@ -127,7 +149,7 @@ faster than several popular containers on the same machine:
 This is synthetic and graph-specific — **not** a universal ranking. Reproduce it:
 
 ```bash
-uv run --with punq --with lagom --with dependency-injector --with wireup \
+uv run --with punq --with lagom --with dependency-injector --with wireup --with dishka \
   python benchmarks/resolve_graph.py
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,21 @@ restores the original registration when the context exits.
 
 Use a scope for request, message, job, or command lifetimes.
 
+## Async
+
+Async factories (`async def`) and async-generator resources are registered with
+the same `add_*_factory` methods and resolved through the async API.
+
+- `await container.aresolve(interface, name=None)` resolves one service, awaiting
+  any async factory in the graph.
+- `async with container.ascope() as scope:` opens an `AsyncScope`. Scoped and
+  transient async resources resolved via `await scope.aresolve(...)` are finalized
+  (LIFO) when the block exits.
+- `await container.aclose()` finalizes singleton async resources at shutdown.
+
+The synchronous `resolve()` raises `AsyncResolutionRequiredException` if the graph
+needs async work. See [async resolution](./async.md) for the full guide.
+
 ## Exceptions
 
 - `ServiceNotRegisteredException`
@@ -57,5 +72,7 @@ Use a scope for request, message, job, or command lifetimes.
 - `MissingTypeAnnotationException`
 - `InvalidLifestyleException`
 - `ContainerValidationException`
+- `AsyncResolutionRequiredException`
+- `PropertyInjectionException`
 
 All exception classes inherit from `DIException`.

--- a/docs/di-frameworks.md
+++ b/docs/di-frameworks.md
@@ -9,10 +9,12 @@ decision, see the [comparison guide](./comparison.md).
 Pick a larger framework when you need any of these — Injex deliberately doesn't do
 them:
 
-- **Async resource lifecycle.** Containers like `dependency-injector` and Dishka can
-  open and close async resources (connection pools, `async with`) as part of
-  resolution. Injex resolves objects; you manage async resource lifetimes yourself
-  or via your framework's lifespan.
+- **Framework-native scopes for async resources.** Injex does open and close async
+  resources (connection pools, `async def ... yield`) via `ascope()` / `aclose()`
+  (see [async resolution](./async.md)). What the larger frameworks add on top is
+  deeper integration with framework-managed request/session scopes — Dishka in
+  particular wires its scopes directly into FastAPI/Litestar. With Injex you open
+  the scope yourself at the request boundary.
 - **A configuration/provider DSL.** If wiring config values through provider objects
   is part of your architecture, `dependency-injector` is purpose-built for it.
 - **Deep framework auto-wiring.** Dishka/Wireup can plug directly into FastAPI or

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -54,7 +54,7 @@ scope features are not exercised, so treat its number as "this graph," not
 Run from the repository root:
 
 ```bash
-uv run --with punq --with lagom --with dependency-injector --with wireup \
+uv run --with punq --with lagom --with dependency-injector --with wireup --with dishka \
   python benchmarks/resolve_graph.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "injex"
-version = "1.4.0"
+version = "1.5.0"
 authors = [{name = "vshulcz", email = "vshulcz@gmail.com"}]
 description = "Tiny typed dependency injection for Python apps"
 readme = "README.md"

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -33,6 +33,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>
@@ -81,11 +82,32 @@
           <li><code>assert_valid()</code> raises <code>ContainerValidationException</code> if validation fails.</li>
         </ul>
 
+        <h2>Async</h2>
+        <p>
+          Async factories (<code>async def</code>) and async-generator resources use the
+          same <code>add_*_factory</code> methods and resolve through the async API.
+        </p>
+        <ul>
+          <li><code>await container.aresolve(interface, name=None)</code> resolves one
+            service, awaiting any async factory in the graph.</li>
+          <li><code>async with container.ascope() as scope:</code> opens an
+            <code>AsyncScope</code>; scoped/transient async resources resolved with
+            <code>await scope.aresolve(...)</code> are finalized LIFO on exit.</li>
+          <li><code>await container.aclose()</code> finalizes singleton async resources
+            at shutdown.</li>
+        </ul>
+        <p>
+          The synchronous <code>resolve()</code> raises
+          <code>AsyncResolutionRequiredException</code> if the graph needs async work.
+          See <a href="./async.html">async resolution</a>.
+        </p>
+
         <h2>Exceptions</h2>
         <p>
           <code>ServiceNotRegisteredException</code>, <code>CyclicDependencyException</code>,
           <code>MissingTypeAnnotationException</code>, <code>InvalidLifestyleException</code>,
-          and <code>ContainerValidationException</code> inherit from <code>DIException</code>.
+          <code>ContainerValidationException</code>, <code>AsyncResolutionRequiredException</code>,
+          and <code>PropertyInjectionException</code> inherit from <code>DIException</code>.
         </p>
 
         <nav class="pager" aria-label="Next pages">

--- a/site/docs/async.html
+++ b/site/docs/async.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Async resolution in Injex — async factories and resource lifecycle</title>
+    <meta
+      name="description"
+      content="Resolve async dependencies in Injex: async def factories, async-generator resources with LIFO teardown, and per-request async scopes for FastAPI — with zero runtime dependencies."
+    />
+    <link rel="canonical" href="https://vshulcz.github.io/injex/docs/async.html" />
+    <meta name="theme-color" content="#070a11" />
+    <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+    <meta property="og:title" content="Async resolution in Injex" />
+    <meta property="og:description" content="Async factories and async-resource lifecycles, with zero runtime dependencies." />
+    <meta property="og:image" content="https://vshulcz.github.io/injex/assets/performance-card.svg" />
+    <link rel="stylesheet" href="../styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Async resolution in Injex",
+        "description": "Resolve async dependencies in Injex: async def factories, async-generator resources with LIFO teardown, and per-request async scopes for FastAPI.",
+        "author": {"@type": "Person", "name": "vshulcz", "url": "https://github.com/vshulcz"},
+        "mainEntityOfPage": "https://vshulcz.github.io/injex/docs/async.html"
+      }
+    </script>
+  </head>
+  <body class="docs-page">
+    <a class="skip-link" href="#content">Skip to content</a>
+    <header class="nav">
+      <a class="brand" href="../">Injex</a>
+      <nav aria-label="Primary navigation">
+        <a href="../">Home</a>
+        <a class="active" href="./">Docs</a>
+        <a href="./comparison.html">Compare</a>
+        <a href="https://github.com/vshulcz/injex">GitHub</a>
+      </nav>
+    </header>
+    <main id="content" class="docs-shell">
+      <aside class="docs-sidebar" aria-label="Documentation navigation">
+        <p class="sidebar-title">Documentation</p>
+        <a href="./">Overview</a>
+        <a href="./getting-started.html">Getting started</a>
+        <a href="./validation.html">Validation</a>
+        <a href="./comparison.html">Comparison</a>
+        <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a class="active" href="./async.html">Async</a>
+        <a href="./di-frameworks.html">DI frameworks</a>
+        <a href="./performance.html">Performance</a>
+        <a href="./recipes.html">Recipes</a>
+        <a href="./migrating-from-factories.html">Migrating from factories</a>
+        <a href="./why.html">Why Injex</a>
+        <a href="./usage.html">Usage scenarios</a>
+        <a href="./python-dependency-injection.html">Python DI guide</a>
+        <a href="./api.html">API reference</a>
+      </aside>
+      <article class="docs-content">
+        <p class="eyebrow">Async</p>
+        <h1>Async resolution</h1>
+        <p class="lead">
+          The synchronous API stays exactly as it is. Async support is a separate
+          path you opt into when a dependency is genuinely asynchronous — an
+          <code>async def</code> factory, or a resource that must be opened and
+          closed around its lifetime. It uses the standard library's
+          <code>contextlib.AsyncExitStack</code>, so still no runtime dependencies.
+        </p>
+
+        <h2>Async factories</h2>
+        <p>
+          Register a coroutine-function factory and resolve it through the async
+          API. The result is cached per its lifetime just like a sync factory:
+        </p>
+        <pre><code>async def load_settings() -> Settings:
+    return await read_config()
+
+container.add_singleton_factory(Settings, load_settings)
+
+async def main() -> None:
+    settings = await container.aresolve(Settings)</code></pre>
+        <p>
+          The sync <code>resolve()</code> raises
+          <code>AsyncResolutionRequiredException</code> if the graph needs async
+          work, so you never silently get back an un-awaited coroutine:
+        </p>
+        <pre><code>container.resolve(Settings)  # AsyncResolutionRequiredException</code></pre>
+        <p>
+          Async "infects" upward: a plain synchronous class that depends on an
+          async factory is also resolved through the async path.
+        </p>
+
+        <h2>Async resources</h2>
+        <p>
+          A resource has a lifetime: a database session, a connection pool, an
+          HTTP client. Declare it as an <strong>async generator</strong> factory:
+        </p>
+        <pre><code>from typing import AsyncIterator
+
+async def db_session(pool: Pool) -> AsyncIterator[Session]:
+    session = await pool.acquire()
+    try:
+        yield session
+    finally:
+        await session.close()
+
+container.add_scoped_factory(Session, db_session)</code></pre>
+        <p>When the resource is finalized depends on its lifetime:</p>
+        <ul>
+          <li><strong>scoped / transient</strong> — finalized when its <code>AsyncScope</code> exits;</li>
+          <li><strong>singleton</strong> — lives until <code>await container.aclose()</code> at shutdown.</li>
+        </ul>
+        <p>Finalization is LIFO, like nested <code>async with</code> blocks.</p>
+
+        <h2>Async scopes</h2>
+        <p>
+          Open a scope with <code>async with</code>. Resources resolved inside are
+          closed when the block exits:
+        </p>
+        <pre><code>async def handle_request() -> None:
+    async with container.ascope() as scope:
+        service = await scope.aresolve(RegisterUser)
+        await service.execute(...)
+    # scoped resources finalized here, LIFO</code></pre>
+        <p>
+          <code>aresolve()</code> on the container (outside a scope) refuses to
+          open a scoped/transient resource it would have to finalize immediately;
+          resolve those inside <code>async with container.ascope()</code> instead.
+        </p>
+
+        <h2>FastAPI</h2>
+        <p>
+          Build the container once in lifespan, open one async scope per request,
+          and close singleton resources on shutdown:
+        </p>
+        <pre><code>@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.container = build_container()
+    yield
+    await app.state.container.aclose()
+
+async def request_scope(request: Request) -> AsyncIterator[AsyncScope]:
+    async with request.app.state.container.ascope() as scope:
+        yield scope
+
+async def get_service(scope: AsyncScope = Depends(request_scope)) -> RegisterUser:
+    return await scope.aresolve(RegisterUser)</code></pre>
+        <p>
+          Full runnable version:
+          <a href="https://github.com/vshulcz/injex/blob/main/examples/fastapi_async.py">examples/fastapi_async.py</a>.
+        </p>
+
+        <h2>Notes</h2>
+        <ul>
+          <li>The async path is interpreted (no compiled flat creator yet); the sync fast path is unaffected.</li>
+          <li>Cycle detection on the async path uses a per-resolution guard, so concurrent resolves don't interfere.</li>
+          <li>
+            A singleton async resource lives until <code>aclose()</code>. In tests, run the resolve
+            and <code>aclose()</code> in the <em>same</em> event loop — <code>asyncio.run()</code>
+            finalizes suspended async generators when it shuts the loop down.
+          </li>
+        </ul>
+
+        <nav class="pager" aria-label="Next pages">
+          <a href="./di-frameworks.html"><small>Next</small>DI framework comparison</a>
+          <a href="./fastapi-depends.html"><small>Related</small>FastAPI boundary</a>
+        </nav>
+      </article>
+    </main>
+    <footer class="site-footer">
+      <span>Injex documentation</span>
+      <span><a href="../">Home</a> · <a href="https://github.com/vshulcz/injex">GitHub</a></span>
+    </footer>
+  </body>
+</html>

--- a/site/docs/comparison.html
+++ b/site/docs/comparison.html
@@ -33,6 +33,7 @@
         <a href="./validation.html">Validation</a>
         <a class="active" href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/di-frameworks.html
+++ b/site/docs/di-frameworks.html
@@ -45,6 +45,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a class="active" href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>
@@ -67,11 +68,14 @@
         <p>Pick a larger framework when you need any of these — Injex deliberately
           doesn't do them:</p>
         <ul>
-          <li><strong>Async resource lifecycle.</strong> Containers like
-            <code>dependency-injector</code> and Dishka open and close async resources
-            (connection pools, <code>async with</code>) as part of resolution. Injex
-            resolves objects; you manage async resource lifetimes yourself or via your
-            framework's lifespan.</li>
+          <li><strong>Framework-native scopes for async resources.</strong> Injex does
+            open and close async resources (connection pools,
+            <code>async def ... yield</code>) via <code>ascope()</code> /
+            <code>aclose()</code> — see <a href="./async.html">async resolution</a>.
+            What the larger frameworks add is deeper integration with framework-managed
+            request/session scopes; Dishka in particular wires its scopes directly into
+            FastAPI/Litestar. With Injex you open the scope yourself at the request
+            boundary.</li>
           <li><strong>A configuration/provider DSL.</strong> If wiring config values
             through provider objects is part of your architecture,
             <code>dependency-injector</code> is purpose-built for it.</li>

--- a/site/docs/fastapi-depends.html
+++ b/site/docs/fastapi-depends.html
@@ -45,6 +45,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a class="active" href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/getting-started.html
+++ b/site/docs/getting-started.html
@@ -33,6 +33,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -35,6 +35,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>
@@ -83,6 +84,11 @@
             <span>Boundary</span>
             <strong>Compared to FastAPI Depends</strong>
             <small>Use FastAPI at the HTTP edge and keep app wiring reusable.</small>
+          </a>
+          <a class="doc-card" href="./async.html">
+            <span>Async</span>
+            <strong>Async resolution</strong>
+            <small>Async factories, async-resource lifecycles, and per-request async scopes.</small>
           </a>
           <a class="doc-card" href="./di-frameworks.html">
             <span>Trade-offs</span>

--- a/site/docs/migrating-from-factories.html
+++ b/site/docs/migrating-from-factories.html
@@ -35,6 +35,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/performance.html
+++ b/site/docs/performance.html
@@ -35,6 +35,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a class="active" href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>
@@ -88,7 +89,7 @@
         </p>
 
         <h2>Reproduce</h2>
-        <pre><code>uv run --with punq --with lagom --with dependency-injector --with wireup \
+        <pre><code>uv run --with punq --with lagom --with dependency-injector --with wireup --with dishka \
   python benchmarks/resolve_graph.py</code></pre>
 
         <nav class="pager" aria-label="Next pages">

--- a/site/docs/python-dependency-injection.html
+++ b/site/docs/python-dependency-injection.html
@@ -88,6 +88,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/recipes.html
+++ b/site/docs/recipes.html
@@ -35,6 +35,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a class="active" href="./recipes.html">Recipes</a>

--- a/site/docs/usage.html
+++ b/site/docs/usage.html
@@ -33,6 +33,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/validation.html
+++ b/site/docs/validation.html
@@ -33,6 +33,7 @@
         <a class="active" href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/docs/why.html
+++ b/site/docs/why.html
@@ -33,6 +33,7 @@
         <a href="./validation.html">Validation</a>
         <a href="./comparison.html">Comparison</a>
         <a href="./fastapi-depends.html">FastAPI boundary</a>
+        <a href="./async.html">Async</a>
         <a href="./di-frameworks.html">DI frameworks</a>
         <a href="./performance.html">Performance</a>
         <a href="./recipes.html">Recipes</a>

--- a/site/index.html
+++ b/site/index.html
@@ -45,7 +45,7 @@
         "codeRepository": "https://github.com/vshulcz/injex",
         "programmingLanguage": "Python",
         "runtimePlatform": "Python 3.10, Python 3.11, Python 3.12, Python 3.13, Python 3.14",
-        "softwareVersion": "1.4.0",
+        "softwareVersion": "1.5.0",
         "applicationCategory": "DeveloperApplication",
         "description": "Tiny typed dependency injection for Python apps: explicit wiring, graph validation, zero runtime dependencies, and fast repeated resolves.",
         "keywords": "python dependency injection, python di container, FastAPI service wiring, Typer dependency injection, clean architecture Python, dependency injection benchmark",

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -84,6 +84,31 @@ def get_register_user(request: Request) -> RegisterUser:
 
 FastAPI adapts HTTP. The application owns service wiring.
 
+## Async resolution
+
+Injex resolves async dependencies through a separate opt-in path; the sync API is
+unchanged. Register a coroutine factory with `add_singleton_factory` /
+`add_*_factory`, or an async-generator resource, then resolve with `aresolve()` /
+`ascope()`. Async resources are finalized LIFO via the standard library's
+`AsyncExitStack` (still zero runtime dependencies): scoped/transient resources
+close when their `AsyncScope` exits, singletons live until `await container.aclose()`.
+The sync `resolve()` raises `AsyncResolutionRequiredException` if the graph needs
+async work, so an un-awaited object is never returned silently.
+
+```python
+async def db_session(settings: Settings):
+    pool = await open_pool(settings.database_url)
+    try:
+        yield pool
+    finally:
+        await pool.aclose()
+
+container.add_scoped_factory(Pool, db_session)
+
+async with container.ascope() as scope:
+    pool = await scope.aresolve(Pool)
+```
+
 ## Compared to larger DI frameworks
 
 Injex is smaller than provider-framework libraries. It is a fit when explicit
@@ -126,7 +151,7 @@ Injex's target shape. They are not a universal ranking.
 Reproduce:
 
 ```bash
-uv run --with punq --with lagom --with dependency-injector --with wireup \
+uv run --with punq --with lagom --with dependency-injector --with wireup --with dishka \
   python benchmarks/resolve_graph.py
 ```
 
@@ -138,6 +163,7 @@ uv run --with punq --with lagom --with dependency-injector --with wireup \
 - Docs: https://vshulcz.github.io/injex/docs/
 - Performance: https://vshulcz.github.io/injex/docs/performance.html
 - FastAPI Depends comparison: https://vshulcz.github.io/injex/docs/fastapi-depends.html
+- Async resolution: https://vshulcz.github.io/injex/docs/async.html
 - DI framework comparison: https://vshulcz.github.io/injex/docs/di-frameworks.html
 - Recipes: https://vshulcz.github.io/injex/docs/recipes.html
 - Article: https://vshulcz.hashnode.dev/where-should-dependency-wiring-live-in-a-python-app

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -34,6 +34,7 @@ Important pages:
 - API reference: https://vshulcz.github.io/injex/docs/api.html
 - Comparison guide: https://vshulcz.github.io/injex/docs/comparison.html
 - FastAPI Depends boundary: https://vshulcz.github.io/injex/docs/fastapi-depends.html
+- Async resolution (async factories, async resources, async scopes): https://vshulcz.github.io/injex/docs/async.html
 - Larger DI frameworks: https://vshulcz.github.io/injex/docs/di-frameworks.html
 - Recipes: https://vshulcz.github.io/injex/docs/recipes.html
 - Migrating from a factories module: https://vshulcz.github.io/injex/docs/migrating-from-factories.html

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -25,6 +25,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://vshulcz.github.io/injex/docs/async.html</loc>
+    <lastmod>2026-06-19</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://vshulcz.github.io/injex/docs/di-frameworks.html</loc>
     <lastmod>2026-06-12</lastmod>
     <changefreq>monthly</changefreq>

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "injex"
-version = "1.4.0"
+version = "1.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Async resolution shipped a couple releases back, but several docs still said it wasn't supported. This syncs everything and prepares the 1.5.0 cut.

## Docs
- New **Async resolution** page on the site (`site/docs/async.html`), added to every doc sidebar, the docs index cards, `sitemap.xml`, `llms.txt`, and `llms-full.txt`.
- README: replaced the stale 'No async resource lifecycle' bullet under *Where it doesn't fit* with a real **Async** section.
- API reference (`docs/api.md` + `site/docs/api.html`): documented `aresolve()`, `ascope()`, `aclose()`, and the two new exceptions.
- `di-frameworks`: reframed the 'where Injex loses' async point — Injex *does* manage async resource lifecycles; what larger frameworks add is framework-native request/session scopes.
- Fixed the benchmark reproduce command (added the missing `--with dishka`) in README, performance docs, and llms-full.

## Release prep
- Bumped `pyproject` to **1.5.0**, cut the `[1.5.0]` changelog section (typed resolve overloads + aresolve guard + docstrings, on top of the already-listed async + PropertyInjectionException work).
- Updated `softwareVersion` in the homepage schema. Left the benchmark-card `1.4.0` labels as-is — those numbers were measured on 1.4.0 and the sync fast path is unchanged.

No code/behavior change in this PR. Tag + PyPI publish are intentionally **not** part of it — that's a separate manual step.

mypy + ruff + 101 tests green.