### PR TITLE
Fast-path aresolve() for fully-synchronous graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project uses semantic versioning.
 
 ## [1.5.0] - 2026-06-19
 
+### Changed
+
+- Faster `aresolve()` for graphs with no async factories: it now reuses the
+  compiled synchronous creator instead of walking the graph with a coroutine per
+  node. On the project benchmark this drops a fully-synchronous `aresolve()` from
+  `~5.1 µs/op` to `~0.41 µs/op` — on par with sync `resolve()`. This is the common
+  FastAPI shape (awaiting `aresolve()` on plain classes). Graphs that actually
+  contain `async def` factories or async resources still take the async path and
+  are unchanged.
+
 ### Added
 
 - Typed `resolve()` / `resolve_all()` / `aresolve()` via `@overload`: passing a

--- a/injex/container.py
+++ b/injex/container.py
@@ -108,6 +108,16 @@ class AsyncScope:
         self, interface: Union[Type, str], name: Optional[str] = None
     ) -> Any:
         """Resolve one service from this async scope (awaits async factories)."""
+        if name is None:
+            # A compiled noscope creator only exists for a graph with no
+            # factories at all (see _build_fast_creator), so it can contain no
+            # async work — resolve it directly and skip the coroutine walk.
+            container = self.container
+            creator = container._noscope_creators.get(interface, _MISSING)
+            if creator is _MISSING:
+                creator = container._prime_noscope_creator(interface)
+            if creator is not None:
+                return creator(None)  # type: ignore[operator]
         return await self.container._aresolve_one(interface, self, name, set())
 
 
@@ -966,6 +976,15 @@ class Container:
         be resolved inside ``async with container.ascope()`` instead, since the
         short-lived scope here would finalize them before you could use them.
         """
+        if name is None:
+            # Fully-sync graph (no factories anywhere): reuse the compiled sync
+            # creator and skip allocating an async scope + coroutine walk. This
+            # is the common FastAPI case — await aresolve() on plain classes.
+            creator = self._noscope_creators.get(interface, _MISSING)
+            if creator is _MISSING:
+                creator = self._prime_noscope_creator(interface)
+            if creator is not None:
+                return creator(None)  # type: ignore[operator]
         registrations = self._registrations.get((interface, name))
         if registrations:
             registration = registrations[0]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -203,6 +203,38 @@ def test_singleton_resource_reopens_after_aclose():
     asyncio.run(main())
 
 
+def test_aresolve_sync_graph_matches_sync_resolve():
+    # A graph with no factories at all has no async work; aresolve must return an
+    # equivalent object and share singletons with the sync resolve path.
+    c = Container()
+    settings = Settings()
+    c.add_instance(Settings, settings)
+
+    class ApiClient:
+        def __init__(self, s: Settings):
+            self.s = s
+
+    class Svc:
+        def __init__(self, client: ApiClient):
+            self.client = client
+
+    c.add_singleton(ApiClient)
+    c.add_transient(Svc)
+
+    async def run():
+        a = await c.aresolve(Svc)
+        async with c.ascope() as scope:
+            b = await scope.aresolve(Svc)
+        sync = c.resolve(Svc)
+        assert isinstance(a, Svc) and isinstance(b, Svc)
+        assert a is not b  # transient
+        # singleton ApiClient shared across aresolve, scope.aresolve, resolve
+        assert a.client is b.client is sync.client
+        assert a.client.s is settings
+
+    asyncio.run(run())
+
+
 def test_assert_valid_accepts_async_factories():
     async def make_settings() -> Settings:
         return Settings()


### PR DESCRIPTION
## Why
`aresolve()` always walked the graph with a coroutine per node and allocated an async scope per call — even when the graph contained no async work at all. That's the common FastAPI shape: you `await aresolve(Service)` but most services are plain classes.

Measured on the project graph:

| path | before | after |
| --- | ---: | ---: |
| sync `resolve()` | 0.40 µs/op | 0.40 µs/op |
| `aresolve()`, fully-sync graph | 5.08 µs/op | **0.41 µs/op** |
| `aresolve()`, async-factory graph | — | 3.02 µs/op (unchanged path) |

## How
A compiled noscope creator is only ever built when the whole subgraph has **no factories at all** (`_build_fast_creator` returns `None` for any factory). So a non-None creator provably contains no async work. `Scope.aresolve` and `Container.aresolve` now check that creator first and call it directly; anything with an `async def` factory or async resource has no such creator and falls through to the unchanged coroutine walk.

Singletons are shared with the sync path (same `_singletons` dict), so identity is consistent across `resolve()` / `aresolve()` / `scope.aresolve()` — covered by a new test.

mypy + ruff + 102 tests green.