### PR TITLE
Compile a flat async creator for aresolve()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@ and this project uses semantic versioning.
 
 ### Changed
 
-- Faster `aresolve()` for graphs with no async factories: it now reuses the
-  compiled synchronous creator instead of walking the graph with a coroutine per
-  node. On the project benchmark this drops a fully-synchronous `aresolve()` from
-  `~5.1 µs/op` to `~0.41 µs/op` — on par with sync `resolve()`. This is the common
-  FastAPI shape (awaiting `aresolve()` on plain classes). Graphs that actually
-  contain `async def` factories or async resources still take the async path and
-  are unchanged.
+- Compiled async resolution. `aresolve()` now compiles a flat `async` creator
+  that inlines the synchronous parts of a graph and awaits only the genuinely
+  async nodes, instead of walking the graph with a coroutine per node:
+  - a graph with no async factories reuses the synchronous compiled creator and
+    drops from `~5.1 µs/op` to `~0.44 µs/op` (on par with sync `resolve()`) — the
+    common FastAPI shape of awaiting `aresolve()` on plain classes;
+  - a graph with an `async def` factory drops from `~3.0 µs/op` to `~1.2 µs/op`
+    on the project benchmark.
+
+  See `benchmarks/resolve_async.py` for a reproducible cross-library comparison.
+  Async resources keep their LIFO finalization semantics; graphs that can't be
+  flattened fall back to the previous interpreted async walk.
 
 ### Added
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -45,6 +45,30 @@ Environment:
 | lagom | `10.010 µs/op` |
 | punq | `58.786 µs/op` |
 
+## Async benchmark
+
+`resolve_async.py` measures the same graph through each library's async API, for
+two shapes: a synchronous graph resolved in an async context (the common FastAPI
+case of awaiting a resolve on plain classes), and a graph whose `Settings` is
+produced by an `async def` factory. Only libraries with a real async path are
+included.
+
+```bash
+uv run --with wireup --with dishka --with dependency-injector \
+  python benchmarks/resolve_async.py
+```
+
+Latest local result (Python `3.13.5`, macOS arm64; `injex 1.5.0`, `wireup 2.11.3`,
+`dishka 1.10.1`):
+
+| Library | Sync graph via async API | Graph with an async factory |
+| --- | ---: | ---: |
+| Injex | `0.441 µs/op` | `1.165 µs/op` |
+| dishka | `1.451 µs/op` | `1.503 µs/op` |
+| Wireup, scope per operation | `1.782 µs/op` | `2.094 µs/op` |
+
+Same caveats as below: synthetic, one graph shape, not a universal ranking.
+
 ## Interpretation
 
 This is not a universal DI ranking. It is a reproducible sanity check for one

--- a/benchmarks/resolve_async.py
+++ b/benchmarks/resolve_async.py
@@ -1,0 +1,316 @@
+"""Async resolution benchmark.
+
+Two shapes, both on the same small service graph used by ``resolve_graph.py``:
+
+1. *sync graph via the async API* — every service is a plain class, but it is
+   resolved through each library's async container. This is the common FastAPI
+   case: you ``await`` the resolve in a handler even though the services
+   themselves are synchronous.
+2. *graph with an async factory* — ``Settings`` is produced by an ``async def``
+   factory (e.g. it awaits config I/O); the rest of the graph depends on it.
+
+Only libraries with a real async resolution API are included (injex, dishka,
+wireup, dependency-injector). punq and lagom have no async path.
+
+Like the sync benchmark this is synthetic and graph-specific — a reproducible
+sanity check for one shape, not a universal ranking.
+
+Run from the repository root:
+
+    uv run --with wireup --with dishka --with dependency-injector \
+      python benchmarks/resolve_async.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import importlib.metadata as metadata
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Awaitable, Callable
+
+import tomllib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from injex import Container as InjexContainer
+
+import wireup
+from dishka import Provider, Scope, from_context, make_async_container, provide
+from wireup import injectable
+
+
+class Settings:
+    def __init__(self) -> None:
+        self.database_url = "sqlite:///:memory:"
+
+
+class ApiClient:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+
+class UserRepository:
+    def __init__(self, client: ApiClient):
+        self.client = client
+
+
+class EmailSender:
+    def __init__(self, client: ApiClient):
+        self.client = client
+
+
+class AuditLog:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+
+class RegisterUser:
+    def __init__(self, repo: UserRepository, email: EmailSender, audit: AuditLog):
+        self.repo = repo
+        self.email = email
+        self.audit = audit
+
+
+settings = Settings()
+
+
+async def make_settings() -> Settings:
+    return settings
+
+
+# wireup resolves string annotations against module globals (the file uses
+# `from __future__ import annotations`), so its injectables live at module scope.
+@injectable
+class WSettings(Settings):
+    pass
+
+
+@injectable
+class WApiClient:
+    def __init__(self, settings: WSettings):
+        self.settings = settings
+
+
+@injectable(lifetime="transient")
+class WRepo:
+    def __init__(self, client: WApiClient):
+        self.client = client
+
+
+@injectable(lifetime="transient")
+class WEmail:
+    def __init__(self, client: WApiClient):
+        self.client = client
+
+
+@injectable(lifetime="transient")
+class WAudit:
+    def __init__(self, settings: WSettings):
+        self.settings = settings
+
+
+@injectable(lifetime="transient")
+class WRegisterUser:
+    def __init__(self, repo: WRepo, email: WEmail, audit: WAudit):
+        self.repo, self.email, self.audit = repo, email, audit
+
+
+@injectable
+async def w_make_settings() -> Settings:
+    return settings
+
+
+@injectable
+class WApiClient2:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+
+@injectable(lifetime="transient")
+class WRepo2:
+    def __init__(self, client: WApiClient2):
+        self.client = client
+
+
+@injectable(lifetime="transient")
+class WEmail2:
+    def __init__(self, client: WApiClient2):
+        self.client = client
+
+
+@injectable(lifetime="transient")
+class WAudit2:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+
+@injectable(lifetime="transient")
+class WRegisterUser2:
+    def __init__(self, repo: WRepo2, email: WEmail2, audit: WAudit2):
+        self.repo, self.email, self.audit = repo, email, audit
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: synchronous graph resolved through the async API.
+# --------------------------------------------------------------------------- #
+def s1_injex() -> Callable[[], Awaitable[object]]:
+    c = InjexContainer()
+    c.add_instance(Settings, settings)
+    c.add_singleton(ApiClient)
+    c.add_transient(UserRepository)
+    c.add_transient(EmailSender)
+    c.add_transient(AuditLog)
+    c.add_transient(RegisterUser)
+    return lambda: c.aresolve(RegisterUser)
+
+
+def s1_dishka() -> Callable[[], Awaitable[object]]:
+    class P(Provider):
+        s = from_context(provides=Settings, scope=Scope.APP)
+        api = provide(ApiClient, scope=Scope.APP)
+        repo = provide(UserRepository, scope=Scope.APP, cache=False)
+        email = provide(EmailSender, scope=Scope.APP, cache=False)
+        audit = provide(AuditLog, scope=Scope.APP, cache=False)
+        ru = provide(RegisterUser, scope=Scope.APP, cache=False)
+
+    container = make_async_container(P(), context={Settings: settings})
+    return lambda: container.get(RegisterUser)
+
+
+def s1_wireup() -> Callable[[], Awaitable[object]]:
+    container = wireup.create_async_container(
+        injectables=[WSettings, WApiClient, WRepo, WEmail, WAudit, WRegisterUser]
+    )
+
+    async def resolve() -> object:
+        async with container.enter_scope() as scoped:
+            return await scoped.get(WRegisterUser)
+
+    return resolve
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: Settings produced by an async factory.
+# --------------------------------------------------------------------------- #
+def s2_injex() -> Callable[[], Awaitable[object]]:
+    c = InjexContainer()
+    c.add_singleton_factory(Settings, make_settings)
+    c.add_singleton(ApiClient)
+    c.add_transient(UserRepository)
+    c.add_transient(EmailSender)
+    c.add_transient(AuditLog)
+    c.add_transient(RegisterUser)
+    return lambda: c.aresolve(RegisterUser)
+
+
+def s2_dishka() -> Callable[[], Awaitable[object]]:
+    class P(Provider):
+        api = provide(ApiClient, scope=Scope.APP)
+        repo = provide(UserRepository, scope=Scope.APP, cache=False)
+        email = provide(EmailSender, scope=Scope.APP, cache=False)
+        audit = provide(AuditLog, scope=Scope.APP, cache=False)
+        ru = provide(RegisterUser, scope=Scope.APP, cache=False)
+
+        @provide(scope=Scope.APP)
+        async def s(self) -> Settings:
+            return settings
+
+    container = make_async_container(P())
+    return lambda: container.get(RegisterUser)
+
+
+def s2_wireup() -> Callable[[], Awaitable[object]]:
+    container = wireup.create_async_container(
+        injectables=[
+            w_make_settings,
+            WApiClient2,
+            WRepo2,
+            WEmail2,
+            WAudit2,
+            WRegisterUser2,
+        ]
+    )
+
+    async def resolve() -> object:
+        async with container.enter_scope() as scoped:
+            return await scoped.get(WRegisterUser2)
+
+    return resolve
+
+
+async def bench(
+    name: str,
+    get: Callable[[], Awaitable[object]],
+    *,
+    iterations: int = 200_000,
+    rounds: int = 9,
+) -> tuple[str, float, float, float]:
+    for _ in range(12_000):
+        await get()
+
+    samples = []
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for _ in range(rounds):
+            start = time.perf_counter_ns()
+            for _ in range(iterations):
+                obj = await get()
+            end = time.perf_counter_ns()
+            assert obj is not None
+            samples.append((end - start) / iterations)
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    return name, statistics.median(samples), min(samples), max(samples)
+
+
+def package_version(name: str) -> str:
+    if name == "injex":
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        data = tomllib.loads(pyproject.read_text())
+        return f"{data['project']['version']} (local checkout)"
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def report(title: str, results: list[tuple[str, float, float, float]]) -> None:
+    print(f"\n{title}")
+    print(f"{'library':<26} {'median µs/op':>14} {'min..max µs':>18}")
+    for name, median, min_value, max_value in sorted(results, key=lambda r: r[1]):
+        print(
+            f"{name:<26} {median / 1000:>14.3f} "
+            f"{min_value / 1000:>7.3f}..{max_value / 1000:<7.3f}"
+        )
+
+
+async def main() -> None:
+    print(f"Python: {platform.python_version()} ({platform.machine()})")
+    for package in ["injex", "wireup", "dishka"]:
+        print(f"{package}: {package_version(package)}")
+
+    s1 = [
+        await bench("injex", s1_injex()),
+        await bench("dishka", s1_dishka()),
+        await bench("wireup scope/op", s1_wireup()),
+    ]
+    report("Scenario 1: synchronous graph via the async API", s1)
+
+    s2 = [
+        await bench("injex", s2_injex()),
+        await bench("dishka", s2_dishka()),
+        await bench("wireup scope/op", s2_wireup()),
+    ]
+    report("Scenario 2: graph with an async def factory (Settings)", s2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/async.md
+++ b/docs/async.md
@@ -121,9 +121,11 @@ A full runnable example is in
 
 ## Notes
 
-- The async path is interpreted (no compiled flat creator yet). Async resolution
-  is dominated by `await` anyway, and keeping it separate means the synchronous
-  fast path is completely unaffected.
+- `aresolve()` compiles a flat `async` creator that inlines the synchronous parts
+  of the graph and awaits only genuinely async nodes; a graph with no async
+  factories reuses the synchronous compiled creator outright. Graphs it can't
+  flatten fall back to an interpreted async walk. The synchronous fast path is
+  unaffected either way.
 - Cycle detection on the async path uses a per-resolution guard, so concurrent
   resolves on one container cannot interfere with each other.
 - A singleton async resource is meant to live until `aclose()`. In tests, run the

--- a/injex/container.py
+++ b/injex/container.py
@@ -108,17 +108,20 @@ class AsyncScope:
         self, interface: Union[Type, str], name: Optional[str] = None
     ) -> Any:
         """Resolve one service from this async scope (awaits async factories)."""
+        container = self.container
         if name is None:
             # A compiled noscope creator only exists for a graph with no
             # factories at all (see _build_fast_creator), so it can contain no
             # async work — resolve it directly and skip the coroutine walk.
-            container = self.container
             creator = container._noscope_creators.get(interface, _MISSING)
             if creator is _MISSING:
                 creator = container._prime_noscope_creator(interface)
             if creator is not None:
                 return creator(None)  # type: ignore[operator]
-        return await self.container._aresolve_one(interface, self, name, set())
+        acreator = container._get_async_creator((interface, name))
+        if acreator is not None:
+            return await acreator[0](self)
+        return await container._aresolve_one(interface, self, name, set())
 
 
 class Container:
@@ -130,6 +133,7 @@ class Container:
         "_async_stack",
         "_resolving_local",
         "_async_resource_keys",
+        "_async_creators",
     )
 
     def __init__(self):
@@ -154,6 +158,15 @@ class Container:
         # registration attribute reads. Value is None when the interface is not
         # eligible for the no-scope fast path. Cleared on every invalidation.
         self._noscope_creators: Dict[Any, Optional[Callable[[Any], Any]]] = {}
+        # Compiled async creators per (interface, name): an `async def` that
+        # inlines the synchronous parts of the graph and awaits only genuine
+        # async nodes, plus a flag for whether it needs an async scope.
+        # Value is None when the graph can't be flattened (falls back to the
+        # interpreted async walk). Cleared on every invalidation.
+        self._async_creators: Dict[
+            Tuple[Union[Type, str], Optional[str]],
+            Optional[Tuple[Callable[[Any], Any], bool]],
+        ] = {}
 
     @property
     def _resolving(self) -> Set[Any]:
@@ -166,6 +179,7 @@ class Container:
     def _invalidate_fast_creators(self) -> None:
         self._version += 1
         self._noscope_creators.clear()
+        self._async_creators.clear()
 
     def register(
         self,
@@ -713,6 +727,150 @@ class Container:
         exec("\n".join(source_lines), namespace, local)  # noqa: S102
         return local["_flat"], needs_scope[0]
 
+    def _get_async_creator(
+        self, key: Tuple[Union[Type, str], Optional[str]]
+    ) -> Optional[Tuple[Callable[[Any], Any], bool]]:
+        cached = self._async_creators.get(key, _MISSING)
+        if cached is not _MISSING:
+            return cached  # type: ignore[return-value]
+        registrations = self._registrations.get(key)
+        result: Optional[Tuple[Callable[[Any], Any], bool]] = None
+        if registrations:
+            result = self._build_async_flat_creator(registrations[0], key)
+        self._async_creators[key] = result
+        return result
+
+    def _build_async_flat_creator(
+        self,
+        registration: Registration,
+        key: Tuple[Union[Type, str], Optional[str]],
+    ) -> Optional[Tuple[Callable[[Any], Any], bool]]:
+        """Compile an ``async def`` creator that inlines the synchronous parts of
+        the graph and awaits only genuine async nodes.
+
+        Synchronous subgraphs reuse the compiled sync fast creator (no coroutine
+        per node); async factories and async resources are delegated to the
+        interpreted async path through a bound getter and awaited once. Returns
+        ``None`` for any shape it cannot flatten (cycles touching inlined nodes,
+        property injection on an inlined transient, container injection), so the
+        caller falls back to the fully interpreted async walk. As in the sync
+        builder, no user names or values are interpolated into generated source.
+        """
+        namespace: Dict[str, Any] = {}
+        prelude: List[str] = []
+        shared: Dict[Any, str] = {}
+        counter = [0]
+        needs_scope = [False]
+
+        def bind(obj: Any, prefix: str) -> str:
+            counter[0] += 1
+            sym = f"{prefix}{counter[0]}"
+            namespace[sym] = obj
+            return sym
+
+        def delegate(
+            reg: Registration, node_key: Tuple[Union[Type, str], Optional[str]]
+        ) -> str:
+            lifestyle = reg.lifestyle
+            if lifestyle == LifeStyle.SCOPED or (
+                reg.is_resource and lifestyle == LifeStyle.TRANSIENT
+            ):
+                needs_scope[0] = True
+
+            def getter(
+                scope: Any, _reg: Registration = reg, _key: Any = node_key
+            ) -> Any:
+                return self._aget_instance_from_registration(_reg, scope, _key, set())
+
+            sym = bind(getter, "ag")
+            if lifestyle == LifeStyle.TRANSIENT:
+                return f"(await {sym}(scope))"
+            if node_key in shared:
+                return shared[node_key]
+            counter[0] += 1
+            var = f"v{counter[0]}"
+            prelude.append(f"{var} = await {sym}(scope)")
+            shared[node_key] = var
+            return var
+
+        def emit(
+            reg: Registration,
+            node_key: Tuple[Union[Type, str], Optional[str]],
+            path: frozenset,
+        ) -> str:
+            if reg.kind == RegistrationType.INSTANCE:
+                if node_key in shared:
+                    return shared[node_key]
+                sym = bind(reg.instance, "c")
+                shared[node_key] = sym
+                return sym
+
+            built = self._build_fast_creator(reg, node_key, set())
+            if built is not None:
+                creator, leaf_needs_scope = built
+                if leaf_needs_scope:
+                    needs_scope[0] = True
+                gsym = bind(creator, "g")
+                if reg.lifestyle == LifeStyle.TRANSIENT:
+                    return f"{gsym}(scope)"
+                if node_key in shared:
+                    return shared[node_key]
+                counter[0] += 1
+                var = f"v{counter[0]}"
+                prelude.append(f"{var} = {gsym}(scope)")
+                shared[node_key] = var
+                return var
+
+            # Async node. Inline a plain transient constructor; delegate factories,
+            # async resources, and cached (singleton/scoped) async services.
+            if reg.kind == RegistrationType.SERVICE and (
+                reg.lifestyle == LifeStyle.TRANSIENT
+            ):
+                cls = reg.implementation
+                if cls is None or node_key in path:
+                    raise _NotFlat
+                plan = self._get_service_plan(reg)
+                if plan.property_dependencies:
+                    return delegate(reg, node_key)
+                child_path = path | {node_key}
+                child_exprs: List[str] = []
+                for dependency_plan in plan.dependencies:
+                    if dependency_plan.inject_container:
+                        raise _NotFlat
+                    if dependency_plan.dependency_type == inspect.Parameter.empty:
+                        raise _NotFlat
+                    dependency_key = dependency_plan.dependency_key
+                    if dependency_key is None:
+                        raise _NotFlat
+                    dependency_regs = self._registrations.get(dependency_key)
+                    if not dependency_regs:
+                        if dependency_plan.has_default:
+                            child_exprs.append(bind(dependency_plan.default, "d"))
+                            continue
+                        if dependency_plan.is_optional:
+                            child_exprs.append("None")
+                            continue
+                        raise _NotFlat
+                    child_exprs.append(
+                        emit(dependency_regs[0], dependency_key, child_path)
+                    )
+                cls_sym = bind(cls, "t")
+                return f"{cls_sym}({', '.join(child_exprs)})"
+
+            return delegate(reg, node_key)
+
+        try:
+            root_expr = emit(registration, key, frozenset())
+        except _NotFlat:
+            return None
+
+        source_lines = ["async def _aflat(scope):"]
+        source_lines.extend(f"    {line}" for line in prelude)
+        source_lines.append(f"    return {root_expr}")
+        local: Dict[str, Any] = {}
+        exec("\n".join(source_lines), namespace, local)  # noqa: S102
+        return local["_aflat"], needs_scope[0]
+
     def _build_fast_creator(
         self,
         registration: Registration,
@@ -997,6 +1155,14 @@ class Container:
                     "aresolve() would finalize it immediately. Resolve it inside "
                     "'async with container.ascope() as scope: await scope.aresolve(...)'."
                 )
+        acreator = self._get_async_creator((interface, name))
+        if acreator is not None:
+            creator_fn, creator_needs_scope = acreator
+            if not creator_needs_scope:
+                # Singletons only: no scope to allocate or finalize.
+                return await creator_fn(None)
+            async with self.ascope() as scope:
+                return await creator_fn(scope)
         async with self.ascope() as scope:
             return await scope.aresolve(interface, name)
 

--- a/site/docs/async.html
+++ b/site/docs/async.html
@@ -151,7 +151,10 @@ async def get_service(scope: AsyncScope = Depends(request_scope)) -> RegisterUse
 
         <h2>Notes</h2>
         <ul>
-          <li>The async path is interpreted (no compiled flat creator yet); the sync fast path is unaffected.</li>
+          <li><code>aresolve()</code> compiles a flat <code>async</code> creator that inlines the
+            synchronous parts of the graph and awaits only genuinely async nodes (a graph with no
+            async factories reuses the synchronous compiled creator); unflattenable graphs fall back
+            to an interpreted async walk. The sync fast path is unaffected.</li>
           <li>Cycle detection on the async path uses a per-resolution guard, so concurrent resolves don't interfere.</li>
           <li>
             A singleton async resource lives until <code>aclose()</code>. In tests, run the resolve


### PR DESCRIPTION
## Why
`aresolve()` walked the graph with a coroutine per node, so on a genuinely-async graph injex was the *slowest* of the async-capable containers. This compiles the async path the way the sync path is already compiled.

Cross-library, same graph (`benchmarks/resolve_async.py`, Python 3.13, macOS arm64):

| library | sync graph via async API | graph with an async factory |
| --- | ---: | ---: |
| **injex** | **0.441 µs/op** | **1.165 µs/op** |
| dishka | 1.451 µs/op | 1.503 µs/op |
| wireup (scope/op) | 1.782 µs/op | 2.094 µs/op |

For injex the async-factory graph went from ~3.0 → ~1.2 µs/op; the fully-sync-via-async case stays at ~0.44 µs/op.

## How
`_build_async_flat_creator` generates an `async def` that:
- inlines plain transient constructors,
- reuses the compiled **sync** fast creator for any fully-synchronous subgraph (no coroutine), and
- delegates async factories / async resources / cached async services to the interpreted path, awaiting each once.

A non-flattenable shape (cycle through an inlined node, property injection on an inlined transient, container injection) returns `None` and falls back to the previous interpreted async walk. Async resources keep LIFO finalization (scoped/transient on the scope's `AsyncExitStack`, singletons until `aclose()`).

## Safety
- Full suite green incl. the async fuzzer (2000 equivalence + 1500 lifecycle graphs) and the 8-thread concurrency stress.
- mypy + ruff clean.
- Sync `resolve()` path untouched.

Note: numbers are synthetic and graph-specific — a reproducible sanity check for one shape, not a universal ranking.