### PR TITLE
Constant-inline singletons + tighten resolve/aresolve dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project uses semantic versioning.
 
 ### Changed
 
+- Faster repeated resolves via singleton constant-inlining. The compiled sync and
+  async creators now realize a scope-free singleton once at build time and inline
+  the instance as a constant, so the generated code constructs the transient spine
+  with no per-resolve getter calls. On the project benchmark sync `resolve()` drops
+  from `0.40` to `0.33 µs/op` (1.25× manual wiring), and singleton-heavy graphs
+  improve by ~60%. The resolve/`aresolve` dispatch was also tightened (single dict
+  lookup, interface-keyed async cache, cache-checked async singletons). Singleton
+  identity, laziness, and override/invalidation semantics are unchanged.
 - Compiled async resolution. `aresolve()` now compiles a flat `async` creator
   that inlines the synchronous parts of a graph and awaits only the genuinely
   async nodes, instead of walking the graph with a coroutine per node:

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ faster than several popular containers on the same machine:
 
 | Library | Median resolve time |
 | --- | ---: |
-| manual wiring | `0.264 µs/op` |
-| **Injex** | **`0.407 µs/op`** |
-| dishka | `0.755 µs/op` |
-| Wireup, same scope | `0.935 µs/op` |
-| dependency-injector | `1.721 µs/op` |
-| lagom | `10.010 µs/op` |
-| punq | `58.786 µs/op` |
+| manual wiring | `0.266 µs/op` |
+| **Injex** | **`0.333 µs/op`** |
+| dishka | `0.786 µs/op` |
+| Wireup, same scope | `0.872 µs/op` |
+| dependency-injector | `1.709 µs/op` |
+| lagom | `9.487 µs/op` |
+| punq | `56.982 µs/op` |
 
 This is synthetic and graph-specific — **not** a universal ranking. Reproduce it:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -27,23 +27,23 @@ uv run --with punq --with lagom --with dependency-injector --with wireup --with 
 Environment:
 
 - Python `3.13.5` on macOS arm64;
-- `injex 1.4.0`;
-- `wireup 2.11.1`;
+- `injex 1.5.0`;
+- `wireup 2.11.3`;
 - `dishka 1.10.1`;
-- `dependency-injector 4.49.0`;
+- `dependency-injector 4.49.1`;
 - `lagom 2.7.7`;
 - `punq 0.7.0`.
 
 | Library | Median resolve time |
 | --- | ---: |
-| manual wiring | `0.264 µs/op` |
-| Injex | `0.407 µs/op` |
-| dishka | `0.755 µs/op` |
-| Wireup, same scope | `0.935 µs/op` |
-| Wireup, scope per operation | `1.559 µs/op` |
-| dependency-injector | `1.721 µs/op` |
-| lagom | `10.010 µs/op` |
-| punq | `58.786 µs/op` |
+| manual wiring | `0.266 µs/op` |
+| Injex | `0.333 µs/op` |
+| dishka | `0.786 µs/op` |
+| Wireup, same scope | `0.872 µs/op` |
+| Wireup, scope per operation | `1.544 µs/op` |
+| dependency-injector | `1.709 µs/op` |
+| lagom | `9.487 µs/op` |
+| punq | `56.982 µs/op` |
 
 ## Async benchmark
 
@@ -63,9 +63,9 @@ Latest local result (Python `3.13.5`, macOS arm64; `injex 1.5.0`, `wireup 2.11.3
 
 | Library | Sync graph via async API | Graph with an async factory |
 | --- | ---: | ---: |
-| Injex | `0.441 µs/op` | `1.165 µs/op` |
-| dishka | `1.451 µs/op` | `1.503 µs/op` |
-| Wireup, scope per operation | `1.782 µs/op` | `2.094 µs/op` |
+| Injex | `0.388 µs/op` | `0.655 µs/op` |
+| dishka | `1.474 µs/op` | `1.515 µs/op` |
+| Wireup, scope per operation | `1.803 µs/op` | `2.090 µs/op` |
 
 Same caveats as below: synthetic, one graph shape, not a universal ranking.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,23 +24,23 @@ Environment used for the project benchmark:
 
 - Python `3.13.5`;
 - macOS arm64;
-- `injex 1.4.0`;
-- `wireup 2.11.1`;
+- `injex 1.5.0`;
+- `wireup 2.11.3`;
 - `dishka 1.10.1`;
-- `dependency-injector 4.49.0`;
+- `dependency-injector 4.49.1`;
 - `lagom 2.7.7`;
 - `punq 0.7.0`.
 
 | Library | Median resolve time |
 | --- | ---: |
-| manual wiring | `0.264 µs/op` |
-| Injex | `0.407 µs/op` |
-| dishka | `0.755 µs/op` |
-| Wireup, same scope | `0.935 µs/op` |
-| Wireup, scope per operation | `1.559 µs/op` |
-| dependency-injector | `1.721 µs/op` |
-| lagom | `10.010 µs/op` |
-| punq | `58.786 µs/op` |
+| manual wiring | `0.266 µs/op` |
+| Injex | `0.333 µs/op` |
+| dishka | `0.786 µs/op` |
+| Wireup, same scope | `0.872 µs/op` |
+| Wireup, scope per operation | `1.544 µs/op` |
+| dependency-injector | `1.709 µs/op` |
+| lagom | `9.487 µs/op` |
+| punq | `56.982 µs/op` |
 
 These numbers are not a universal ranking. They are a small synthetic benchmark
 for one graph shape. Different lifetimes, framework integrations, factories,

--- a/injex/container.py
+++ b/injex/container.py
@@ -68,7 +68,17 @@ class Scope:
     def resolve(self, interface: str, name: Optional[str] = None) -> Any: ...
     def resolve(self, interface: Union[Type, str], name: Optional[str] = None) -> Any:
         """Resolve one service from this scope."""
-        return self.container._resolve_one(interface, self, name)
+        container = self.container
+        if name is None:
+            # A noscope creator only exists for graphs with no scoped services,
+            # so it is safe to use inside a scope too (nothing is per-scope).
+            try:
+                creator = container._noscope_creators[interface]
+            except KeyError:
+                creator = container._prime_noscope_creator(interface)
+            if creator is not None:
+                return creator(None)  # type: ignore[operator]
+        return container._resolve_one(interface, self, name)
 
     @overload
     def resolve_all(
@@ -113,12 +123,13 @@ class AsyncScope:
             # A compiled noscope creator only exists for a graph with no
             # factories at all (see _build_fast_creator), so it can contain no
             # async work — resolve it directly and skip the coroutine walk.
-            creator = container._noscope_creators.get(interface, _MISSING)
-            if creator is _MISSING:
+            try:
+                creator = container._noscope_creators[interface]
+            except KeyError:
                 creator = container._prime_noscope_creator(interface)
             if creator is not None:
                 return creator(None)  # type: ignore[operator]
-        acreator = container._get_async_creator((interface, name))
+        acreator = container._get_async_creator(interface, name)
         if acreator is not None:
             return await acreator[0](self)
         return await container._aresolve_one(interface, self, name, set())
@@ -164,7 +175,7 @@ class Container:
         # Value is None when the graph can't be flattened (falls back to the
         # interpreted async walk). Cleared on every invalidation.
         self._async_creators: Dict[
-            Tuple[Union[Type, str], Optional[str]],
+            Any,
             Optional[Tuple[Callable[[Any], Any], bool]],
         ] = {}
 
@@ -317,8 +328,9 @@ class Container:
         """Resolve one service. Raises AsyncResolutionRequiredException if the
         graph needs async work — use aresolve()/ascope() then."""
         if name is None:
-            creator = self._noscope_creators.get(interface, _MISSING)
-            if creator is _MISSING:
+            try:
+                creator = self._noscope_creators[interface]
+            except KeyError:
                 creator = self._prime_noscope_creator(interface)
             if creator is not None:
                 return creator(None)  # type: ignore[operator]
@@ -339,6 +351,11 @@ class Container:
                 and not registration.fast_creator_needs_scope
             ):
                 creator = registration.fast_creator
+                # A scope-free singleton root is immutable until invalidation
+                # (which rebuilds this entry). Realize it once and dispatch a
+                # plain constant, skipping the cached-getter's sentinel check.
+                if registration.lifestyle == LifeStyle.SINGLETON:
+                    creator = _make_constant_creator(creator(None))
         self._noscope_creators[interface] = creator
         return creator
 
@@ -681,6 +698,14 @@ class Container:
                 if built is None:
                     raise _NotFlat
                 leaf_creator, leaf_needs_scope = built
+                # A singleton whose subgraph needs no scope is immutable until the
+                # next invalidation (which rebuilds this creator). Realize it once
+                # here and inline the instance as a constant, so the generated code
+                # constructs the transient spine with zero getter calls.
+                if lifestyle == LifeStyle.SINGLETON and not leaf_needs_scope:
+                    sym = bind(leaf_creator(None), "s")  # type: ignore[arg-type]
+                    shared[node_key] = sym
+                    return sym
                 if lifestyle == LifeStyle.SCOPED or leaf_needs_scope:
                     needs_scope[0] = True
                 getter = bind(leaf_creator, "g")
@@ -728,16 +753,20 @@ class Container:
         return local["_flat"], needs_scope[0]
 
     def _get_async_creator(
-        self, key: Tuple[Union[Type, str], Optional[str]]
+        self, interface: Union[Type, str], name: Optional[str]
     ) -> Optional[Tuple[Callable[[Any], Any], bool]]:
-        cached = self._async_creators.get(key, _MISSING)
+        # Cache under the bare interface for the common name=None case so the
+        # hot path does a direct dict lookup with no per-call tuple allocation.
+        cache_key: Any = interface if name is None else (interface, name)
+        cached = self._async_creators.get(cache_key, _MISSING)
         if cached is not _MISSING:
             return cached  # type: ignore[return-value]
-        registrations = self._registrations.get(key)
+        reg_key = (interface, name)
+        registrations = self._registrations.get(reg_key)
         result: Optional[Tuple[Callable[[Any], Any], bool]] = None
         if registrations:
-            result = self._build_async_flat_creator(registrations[0], key)
-        self._async_creators[key] = result
+            result = self._build_async_flat_creator(registrations[0], reg_key)
+        self._async_creators[cache_key] = result
         return result
 
     def _build_async_flat_creator(
@@ -789,7 +818,23 @@ class Container:
                 return shared[node_key]
             counter[0] += 1
             var = f"v{counter[0]}"
-            prelude.append(f"{var} = await {sym}(scope)")
+            # Cached singleton/scoped: check the cache synchronously and only
+            # create+await the getter coroutine on a miss. After warmup this is a
+            # plain dict lookup with no coroutine churn.
+            ms = bind(_MISSING, "m")
+            if lifestyle == LifeStyle.SINGLETON:
+                ik = bind((node_key, reg), "ik")
+                sg = bind(self._singletons.get, "sg")
+                prelude.append(f"{var} = {sg}({ik}, {ms})")
+                prelude.append(f"if {var} is {ms}:")
+                prelude.append(f"    {var} = await {sym}(scope)")
+            elif lifestyle == LifeStyle.SCOPED:
+                ik = bind((node_key, reg), "ik")
+                prelude.append(f"{var} = scope._scoped_instances.get({ik}, {ms})")
+                prelude.append(f"if {var} is {ms}:")
+                prelude.append(f"    {var} = await {sym}(scope)")
+            else:
+                prelude.append(f"{var} = await {sym}(scope)")
             shared[node_key] = var
             return var
 
@@ -808,6 +853,14 @@ class Container:
             built = self._build_fast_creator(reg, node_key, set())
             if built is not None:
                 creator, leaf_needs_scope = built
+                # Realize a scope-free singleton once and inline it as a constant
+                # (same reasoning as the sync flat builder).
+                if reg.lifestyle == LifeStyle.SINGLETON and not leaf_needs_scope:
+                    if node_key in shared:
+                        return shared[node_key]
+                    sym = bind(creator(None), "s")  # type: ignore[arg-type]
+                    shared[node_key] = sym
+                    return sym
                 if leaf_needs_scope:
                     needs_scope[0] = True
                 gsym = bind(creator, "g")
@@ -1138,11 +1191,30 @@ class Container:
             # Fully-sync graph (no factories anywhere): reuse the compiled sync
             # creator and skip allocating an async scope + coroutine walk. This
             # is the common FastAPI case — await aresolve() on plain classes.
-            creator = self._noscope_creators.get(interface, _MISSING)
-            if creator is _MISSING:
+            try:
+                creator = self._noscope_creators[interface]
+            except KeyError:
                 creator = self._prime_noscope_creator(interface)
             if creator is not None:
                 return creator(None)  # type: ignore[operator]
+        acreator = self._get_async_creator(interface, name)
+        if acreator is not None:
+            creator_fn, creator_needs_scope = acreator
+            if not creator_needs_scope:
+                # Singletons only: no scope to allocate or finalize, and a
+                # top-level transient/scoped resource always needs a scope, so
+                # the resource footgun cannot apply here — skip the guard lookup.
+                return await creator_fn(None)
+            self._guard_top_async_resource(interface, name)
+            async with self.ascope() as scope:
+                return await creator_fn(scope)
+        self._guard_top_async_resource(interface, name)
+        async with self.ascope() as scope:
+            return await scope.aresolve(interface, name)
+
+    def _guard_top_async_resource(
+        self, interface: Union[Type, str], name: Optional[str]
+    ) -> None:
         registrations = self._registrations.get((interface, name))
         if registrations:
             registration = registrations[0]
@@ -1155,16 +1227,6 @@ class Container:
                     "aresolve() would finalize it immediately. Resolve it inside "
                     "'async with container.ascope() as scope: await scope.aresolve(...)'."
                 )
-        acreator = self._get_async_creator((interface, name))
-        if acreator is not None:
-            creator_fn, creator_needs_scope = acreator
-            if not creator_needs_scope:
-                # Singletons only: no scope to allocate or finalize.
-                return await creator_fn(None)
-            async with self.ascope() as scope:
-                return await creator_fn(scope)
-        async with self.ascope() as scope:
-            return await scope.aresolve(interface, name)
 
     async def aclose(self) -> None:
         """Finalize singleton async resources. Call once at application shutdown."""

--- a/site/docs/performance.html
+++ b/site/docs/performance.html
@@ -70,14 +70,14 @@
             <tr><th>Library</th><th>Median resolve time</th></tr>
           </thead>
           <tbody>
-            <tr><td>manual wiring</td><td><code>0.264 µs/op</code></td></tr>
-            <tr><td>Injex</td><td><code>0.407 µs/op</code></td></tr>
-            <tr><td>dishka</td><td><code>0.755 µs/op</code></td></tr>
-            <tr><td>Wireup, same scope</td><td><code>0.935 µs/op</code></td></tr>
-            <tr><td>Wireup, scope per operation</td><td><code>1.559 µs/op</code></td></tr>
-            <tr><td>dependency-injector</td><td><code>1.721 µs/op</code></td></tr>
-            <tr><td>lagom</td><td><code>10.010 µs/op</code></td></tr>
-            <tr><td>punq</td><td><code>58.786 µs/op</code></td></tr>
+            <tr><td>manual wiring</td><td><code>0.266 µs/op</code></td></tr>
+            <tr><td>Injex</td><td><code>0.333 µs/op</code></td></tr>
+            <tr><td>dishka</td><td><code>0.786 µs/op</code></td></tr>
+            <tr><td>Wireup, same scope</td><td><code>0.872 µs/op</code></td></tr>
+            <tr><td>Wireup, scope per operation</td><td><code>1.544 µs/op</code></td></tr>
+            <tr><td>dependency-injector</td><td><code>1.709 µs/op</code></td></tr>
+            <tr><td>lagom</td><td><code>9.487 µs/op</code></td></tr>
+            <tr><td>punq</td><td><code>56.982 µs/op</code></td></tr>
           </tbody>
           </table>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -96,7 +96,7 @@
             <span class="badge">Python 3.10–3.14</span>
             <span class="badge">PEP 561 typed</span>
             <span class="badge">No runtime deps</span>
-            <span class="badge">0.407 µs/op benchmark</span>
+            <span class="badge">0.333 µs/op benchmark</span>
           </div>
           <div class="actions">
             <a class="primary" href="./docs/getting-started.html">Start in 2 minutes</a>
@@ -139,7 +139,7 @@
       <section class="strip section" aria-label="Project highlights">
         <div><strong>0</strong><span>runtime dependencies</span></div>
         <div><strong>3</strong><span>lifetimes: singleton, transient, scoped</span></div>
-        <div><strong>0.407 µs</strong><span>median resolve benchmark</span></div>
+        <div><strong>0.333 µs</strong><span>median resolve benchmark</span></div>
         <div><strong>typed</strong><span>constructor injection from annotations</span></div>
       </section>
 
@@ -154,7 +154,7 @@
           </p>
           <p>
             On this synthetic benchmark, Injex resolves the graph in
-            <strong>0.407 µs/op</strong>, ahead of Wireup same-scope on the same
+            <strong>0.333 µs/op</strong>, ahead of Wireup same-scope on the same
             machine while staying zero-dependency and explicit.
           </p>
           <div class="actions">
@@ -165,16 +165,16 @@
         <div class="benchmark-panel" aria-label="Resolve benchmark results">
           <div class="benchmark-leader">
             <span>Injex</span>
-            <strong>0.407 µs/op</strong>
+            <strong>0.333 µs/op</strong>
             <small>median resolve time</small>
           </div>
           <div class="benchmark-bars">
-            <div style="--bar: 28%"><span>manual</span><strong>0.264</strong></div>
-            <div class="accent" style="--bar: 44%"><span>Injex</span><strong>0.407</strong></div>
-            <div style="--bar: 81%"><span>dishka</span><strong>0.755</strong></div>
-            <div style="--bar: 100%"><span>Wireup same scope</span><strong>0.935</strong></div>
-            <div style="--bar: 100%"><span>Wireup scope/op</span><strong>1.559</strong></div>
-            <div style="--bar: 100%"><span>dependency-injector</span><strong>1.721</strong></div>
+            <div style="--bar: 31%"><span>manual</span><strong>0.266</strong></div>
+            <div class="accent" style="--bar: 38%"><span>Injex</span><strong>0.333</strong></div>
+            <div style="--bar: 90%"><span>dishka</span><strong>0.786</strong></div>
+            <div style="--bar: 100%"><span>Wireup same scope</span><strong>0.872</strong></div>
+            <div style="--bar: 100%"><span>Wireup scope/op</span><strong>1.544</strong></div>
+            <div style="--bar: 100%"><span>dependency-injector</span><strong>1.709</strong></div>
           </div>
           <p>
             Median µs/op. Smaller is better. Synthetic graph; measure your own app.

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -136,14 +136,14 @@ Local benchmark result on Python 3.13.5 / macOS arm64:
 
 | Library | Median resolve time |
 | --- | ---: |
-| manual wiring | `0.264 µs/op` |
-| Injex | `0.407 µs/op` |
-| dishka | `0.755 µs/op` |
-| Wireup, same scope | `0.935 µs/op` |
-| Wireup, scope per operation | `1.559 µs/op` |
-| dependency-injector | `1.721 µs/op` |
-| lagom | `10.010 µs/op` |
-| punq | `58.786 µs/op` |
+| manual wiring | `0.266 µs/op` |
+| Injex | `0.333 µs/op` |
+| dishka | `0.786 µs/op` |
+| Wireup, same scope | `0.872 µs/op` |
+| Wireup, scope per operation | `1.544 µs/op` |
+| dependency-injector | `1.709 µs/op` |
+| lagom | `9.487 µs/op` |
+| punq | `56.982 µs/op` |
 
 These numbers are synthetic and graph-specific. They show low overhead for
 Injex's target shape. They are not a universal ranking.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -17,7 +17,7 @@ Key facts:
 - Lifetimes: singleton, transient, scoped
 - Features: typed constructor injection, factories, instances, named
   registrations, optional dependencies, test overrides, graph validation
-- Performance snapshot: `0.407 µs/op` median resolve time on the project small
+- Performance snapshot: `0.333 µs/op` median resolve time on the project small
   service-graph benchmark
 
 Primary URLs:

--- a/tests/test_perf_semantics.py
+++ b/tests/test_perf_semantics.py
@@ -1,0 +1,132 @@
+"""Semantics that the compiled fast paths must preserve.
+
+These pin the behaviours the constant-inlining / cache-check optimisations could
+plausibly break: singleton identity and single-construction across every resolve
+entry point, laziness (only graphs that are actually resolved construct their
+singletons), and correct rebuild after an override.
+"""
+
+import asyncio
+
+from injex import Container
+
+
+class Settings:
+    instances = 0
+
+    def __init__(self) -> None:
+        Settings.instances += 1
+
+
+class ApiClient:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+
+class Repo:
+    def __init__(self, client: ApiClient):
+        self.client = client
+
+
+class Service:
+    def __init__(self, repo: Repo, client: ApiClient):
+        self.repo = repo
+        self.client = client
+
+
+def _container() -> Container:
+    Settings.instances = 0
+    c = Container()
+    c.add_singleton(Settings)
+    c.add_singleton(ApiClient)
+    c.add_transient(Repo)
+    c.add_transient(Service)
+    return c
+
+
+def test_singleton_inlined_but_constructed_once():
+    c = _container()
+    a = c.resolve(Service)
+    b = c.resolve(Service)
+    assert a is not b  # transient root
+    # the shared singleton is the same object and was built exactly once
+    assert a.client is b.client
+    assert a.repo.client is a.client
+    assert Settings.instances == 1
+
+
+def test_singleton_identity_across_entry_points():
+    c = _container()
+    s_root = c.resolve(Service)
+    scoped = c.create_scope().resolve(Service)
+    aresolved = asyncio.run(c.aresolve(Service))
+
+    # ApiClient singleton is identical no matter how Service was resolved
+    assert s_root.client is scoped.client is aresolved.client
+    # Settings singleton still built once across all three paths
+    assert Settings.instances == 1
+
+
+def test_singleton_root_returns_same_instance():
+    c = _container()
+    a = c.resolve(ApiClient)
+    b = c.resolve(ApiClient)
+    assert a is b
+    assert a is c.create_scope().resolve(ApiClient)
+    assert a is asyncio.run(c.aresolve(ApiClient))
+
+
+def test_unresolved_singletons_are_not_eagerly_built():
+    # Resolving Repo must not construct a singleton that only Service needs...
+    Settings.instances = 0
+    c = Container()
+    c.add_singleton(Settings)
+    c.add_singleton(ApiClient)
+    c.add_transient(Repo)
+
+    class Unrelated:
+        def __init__(self) -> None:
+            raise AssertionError("must not be constructed")
+
+    c.add_singleton(Unrelated)
+
+    c.resolve(Repo)  # only needs ApiClient -> Settings
+    assert Settings.instances == 1  # built, because Repo needs it
+    # Unrelated never resolved -> never constructed (no eager realization leak)
+
+
+def test_override_after_warmup_rebuilds():
+    c = _container()
+    first = c.resolve(Service)
+    real_client = first.client
+
+    fake = ApiClient(Settings())
+    with c.override(ApiClient, instance=fake):
+        during = c.resolve(Service)
+        assert during.client is fake  # inlined creator rebuilt with the override
+
+    after = c.resolve(Service)
+    assert after.client is real_client  # restored, not the fake
+    assert after.client is not fake
+
+
+def test_async_cached_singleton_path():
+    async def make_settings() -> Settings:
+        return Settings()
+
+    async def main():
+        Settings.instances = 0
+        c = Container()
+        c.add_singleton_factory(Settings, make_settings)
+        c.add_singleton(ApiClient)
+        c.add_transient(Repo)
+        c.add_transient(Service)
+
+        a = await c.aresolve(Service)
+        b = await c.aresolve(Service)
+        assert a is not b  # transient root
+        assert a.client is b.client  # async-derived singleton shared
+        assert a.client.settings is b.client.settings
+        assert Settings.instances == 1  # async singleton awaited/built once
+
+    asyncio.run(main())


### PR DESCRIPTION
Makes repeated resolves faster on both the sync and async paths, with the biggest gains on singleton-heavy graphs (the common real-app shape: a few app-wide singletons + per-request transients).

## Numbers (one consistent run, Python 3.13, macOS arm64)

Sync resolve (`benchmarks/resolve_graph.py`):

| | before | after |
| --- | ---: | ---: |
| injex | 0.407 µs/op | **0.333 µs/op** |
| x manual | 1.53x | **1.25x** |

Async (`benchmarks/resolve_async.py`):

| graph | injex before | injex after | dishka | wireup |
| --- | ---: | ---: | ---: | ---: |
| sync graph via async API | 0.441 | **0.388** | 1.474 | 1.803 |
| graph with an async factory | 1.165 | **0.655** | 1.515 | 2.090 |

Per-shape (research harness), singleton-heavy graphs: **−63% sync / −59% async**; singleton-root resolves: −27%.

## What changed
1. **Singleton constant-inlining.** A scope-free singleton is immutable until the next invalidation (which rebuilds the creator), so it is realized once at build time and inlined into the generated code as a constant. The compiled creator then constructs the transient spine with zero getter calls. Applied to both the sync flat builder and the async flat builder, and to singleton *roots* in the noscope dispatch.
2. **Tighter dispatch.** `try/except KeyError` instead of `.get(_MISSING)` + identity check; a `Scope.resolve` fast path (it used to always take the slow walk); an interface-keyed async-creator cache (no per-call tuple allocation); a synchronous cache check for async singletons/scoped (await only on a miss); and the `aresolve()` resource guard only when a scope is actually needed.

## Safety
Semantics preserved and pinned by `tests/test_perf_semantics.py` (singleton identity across `resolve`/`Scope.resolve`/`aresolve`, single construction, laziness — unresolved singletons aren't eagerly built, override-after-warmup rebuild, async cached-singleton path), on top of the existing flat-creator + async fuzzers (3500 random graphs) and the 8-thread concurrency stress. A singleton async *resource* is never constant-inlined (it can be evicted by `aclose()`); it stays delegated. mypy + ruff clean; 108 tests pass.

Published benchmark numbers across README/docs/site were refreshed from the same single run.