### PR TITLE
Rewrite the tutorial in a plainer voice; tidy the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,12 @@ and this project uses semantic versioning.
 
 ### Changed
 
-- Faster repeated resolves via singleton constant-inlining. The compiled sync and
-  async creators now realize a scope-free singleton once at build time and inline
-  the instance as a constant, so the generated code constructs the transient spine
-  with no per-resolve getter calls. On the project benchmark sync `resolve()` drops
-  from `0.40` to `0.33 µs/op` (1.25× manual wiring), and singleton-heavy graphs
-  improve by ~60%. The resolve/`aresolve` dispatch was also tightened (single dict
-  lookup, interface-keyed async cache, cache-checked async singletons). Singleton
-  identity, laziness, and override/invalidation semantics are unchanged.
-- Compiled async resolution. `aresolve()` now compiles a flat `async` creator
-  that inlines the synchronous parts of a graph and awaits only the genuinely
-  async nodes, instead of walking the graph with a coroutine per node:
-  - a graph with no async factories reuses the synchronous compiled creator and
-    drops from `~5.1 µs/op` to `~0.44 µs/op` (on par with sync `resolve()`) — the
-    common FastAPI shape of awaiting `aresolve()` on plain classes;
-  - a graph with an `async def` factory drops from `~3.0 µs/op` to `~1.2 µs/op`
-    on the project benchmark.
-
-  See `benchmarks/resolve_async.py` for a reproducible cross-library comparison.
-  Async resources keep their LIFO finalization semantics; graphs that can't be
-  flattened fall back to the previous interpreted async walk.
+- Faster repeated resolves. The compiled creator now realizes scope-free
+  singletons once at build time and inlines them as constants, so resolving a
+  graph runs its constructors with no per-resolve getter calls. Sync `resolve()`
+  drops from `0.40` to `0.33 µs/op` (1.25× manual wiring) on the project
+  benchmark; singleton-heavy graphs improve ~60%. Singleton identity, laziness,
+  and override semantics are unchanged.
 
 ### Added
 
@@ -42,20 +28,20 @@ and this project uses semantic versioning.
   scoped/transient async resource directly (which it would finalize immediately),
   pointing at `async with container.ascope()`.
 - Docstrings on the public registration and scope methods.
-- Async resolution, sync-first and still zero-dependency. `await container.aresolve(T)`
+- Async resolution, zero-dependency and sync-first. `await container.aresolve(T)`
   and `async with container.ascope() as scope: await scope.aresolve(T)` await
-  `async def` factories and manage async resources: register an async-generator
-  factory (`async def f(...): ...; yield x; await cleanup()`) and the yielded value
-  is finalized when its scope exits (scoped/transient) or on `await container.aclose()`
-  (singleton), via a stdlib `AsyncExitStack`. The sync `resolve()` raises a clear
-  `AsyncResolutionRequiredException` if the graph needs async work. Cycle detection
-  on the async path uses a per-resolution guard (safe under concurrent resolves).
-  The synchronous fast path is untouched — same compiled creators, same ~0.4 µs/op.
+  `async def` factories and manage async-generator resources (`yield` then
+  `await cleanup()`), finalized when the scope exits, or on
+  `await container.aclose()` for singletons, via a stdlib `AsyncExitStack`.
+  `aresolve()` compiles a flat async creator that inlines the synchronous parts of
+  the graph and awaits only the genuinely async nodes: a fully-sync graph resolves
+  at sync speed (~0.44 µs/op), a graph with an `async def` factory at ~1.2 µs/op.
+  Sync `resolve()` raises `AsyncResolutionRequiredException` if the graph needs
+  async work, and is itself untouched. See `benchmarks/resolve_async.py`.
 - `PropertyInjectionException` with a clear message when property injection
-  (`@inject` methods) targets a `__slots__` type or a frozen dataclass, instead
-  of a raw `AttributeError` / `FrozenInstanceError`. Constructor injection into
-  such types already worked (the compiled path calls the constructor directly and
-  never sets attributes) and is unaffected; the hot path is untouched.
+  (`@inject` methods) targets a `__slots__` type or a frozen dataclass, instead of
+  a raw `AttributeError` / `FrozenInstanceError`. Constructor injection into those
+  types is unaffected.
 
 ## [1.4.0] - 2026-06-12
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,380 +1,232 @@
-# Injex Documentation
+# Tutorial
 
-## Table of Contents
+This walks through Injex feature by feature, starting from the smallest useful
+container and adding things as you hit a reason for them. If you just want the
+two-minute version, the [README](../README.md) quick start is enough; come back
+here when you need factories, scopes, named registrations, or property injection.
 
-1. [Core Concepts](#core-concepts)
-- [Service Registration](#service-registration)
-    - [Singleton services](#singleton-services)
-    - [Transient services](#transient-services)
-    - [Scoped services](#scoped-services)
-- [Factory Registration](#factory-registration)
-    - [Singleton Factories](#singleton-factories)
-    - [Transient Factories](#transient-factories)
-    - [Scoped Factories](#scoped-factories)
-- [Instance Registration](#instance-registration)
-- [Resolving Dependencies](#resolving-dependencies)
-    - [Resolving Single Instances](#resolving-single-instances)
-    - [Resolving Multiple Instances](#resolving-multiple-instances)
-- [Property Injection](#property-injection)
-- [Named Registrations](#named-registrations)
-- [Optional Dependencies](#optional-dependencies)
-- [Test Overrides](#test-overrides)
-- [Container Validation](#container-validation)
-2. [Advanced Topics](#advanced-topics)
-- [Scopes and Scoped Services](#scopes-and-scoped-services)
-- [Cyclic Dependencies](#cyclic-dependencies)
-- [Error Handling](#error-handling)
-3. [Real-World Examples](#real-world-examples)
-- [Building a Mediator with Pipeline Behaviors](#building-a-mediator-with-pipeline-behaviors)
-- [Creating an API Service with Database Integration](#creating-an-api-service-with-database-integration)
+For depth on a specific topic, each section links to its own guide.
 
-## Core Concepts
+## The core loop
 
-### Service Registration
+You register classes against the container at startup, then resolve them. Injex
+reads constructor type hints to figure out what to build.
 
-Registering services is the cornerstone of using Injex. You can register classes with different lifestyles.
-
-#### Singleton Services
-A singleton service is created once and reused throughout the application's lifetime.
 ```python
 from injex import Container
 
-class ConfigurationManager:
-    pass
+
+class UserRepository:
+    def save(self, email: str) -> int:
+        return 42
+
+
+class RegisterUser:
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
 
 container = Container()
-container.add_singleton(ConfigurationManager)
+container.add_transient(UserRepository)
+container.add_transient(RegisterUser)
 
-config1 = container.resolve(ConfigurationManager)
-config2 = container.resolve(ConfigurationManager)
-assert config1 is config2  # Same instance
+use_case = container.resolve(RegisterUser)  # UserRepository built and injected
 ```
 
-#### Transient Services
-A transient service creates a new instance every time it is resolved.
+`RegisterUser` never names `UserRepository` anywhere except its own constructor.
+That is the whole point: classes declare what they need, the container decides
+where instances come from.
+
+## Lifetimes
+
+A registration has a lifetime that controls how often the instance is rebuilt:
+
+- `add_singleton` — built once, shared for the life of the container. Use it for
+  configuration, connection pools, and clients.
+- `add_transient` — a fresh instance on every resolve. Use it for use cases and
+  anything that should not carry state between calls.
+- `add_scoped` — one instance per scope (see [Scopes](#scopes) below). Use it for
+  request- or job-owned objects like a database session.
+
 ```python
-class UserService:
-    pass
-
-container.add_transient(UserService)
-
-user_service1 = container.resolve(UserService)
-user_service2 = container.resolve(UserService)
-assert user_service1 is not user_service2  # Different instances
+container.add_singleton(Settings)
+container.add_transient(RegisterUser)
+container.add_scoped(DbSession)
 ```
 
-#### Scoped Services
-A scoped service is unique within a scope but shared within that scope.
+The second argument is the implementation, if it differs from the key:
+
 ```python
-class RequestHandler:
-    pass
-
-container.add_scoped(RequestHandler)
-
-scope1 = container.create_scope()
-scope2 = container.create_scope()
-
-handler1 = scope1.resolve(RequestHandler)
-handler2 = scope1.resolve(RequestHandler)
-handler3 = scope2.resolve(RequestHandler)
-
-assert handler1 is handler2  # Same instance within scope1
-assert handler1 is not handler3  # Different instances across scopes
+container.add_singleton(Cache, RedisCache)  # resolve(Cache) -> RedisCache
 ```
 
-### Factory Registration
+## Factories
 
-Factories allow you to define custom logic for creating instances.
+When construction needs logic the constructor can't express — reading an env var,
+building from a connection string — register a factory instead of a class. The
+factory's own parameters are injected too.
 
-#### Singleton Factories
 ```python
-def create_database_connection():
-    return DatabaseConnection(pool_size=5)
+def make_pool(settings: Settings) -> ConnectionPool:
+    return ConnectionPool(settings.database_url, size=5)
 
-container.add_singleton_factory(DatabaseConnection, create_database_connection)
 
-db1 = container.resolve(DatabaseConnection)
-db2 = container.resolve(DatabaseConnection)
-assert db1 is db2  # Same instance
+container.add_singleton_factory(ConnectionPool, make_pool)
 ```
 
-#### Transient Factories
+There is a factory variant for each lifetime: `add_singleton_factory`,
+`add_transient_factory`, `add_scoped_factory`. Async (`async def`) factories and
+async-generator resources go through the async API — see [Async](./async.md).
+
+## Existing instances
+
+If you already hold an object, register it directly. It is treated as a
+singleton.
+
 ```python
-def create_user():
-    return User(id=generate_unique_id())
-
-container.add_transient_factory(User, create_user)
-
-user1 = container.resolve(User)
-user2 = container.resolve(User)
-assert user1 is not user2  # Different instances
+container.add_instance(Settings, load_settings())
 ```
 
-#### Scoped Factories
+## Scopes
+
+A scope is a boundary that scoped services live inside of — typically one web
+request or one background job. Scoped services are shared within a scope and
+rebuilt for the next one.
+
 ```python
-def create_request_context():
-    return RequestContext(request_id=generate_request_id())
+container.add_scoped(DbSession)
 
-container.add_scoped_factory(RequestContext, create_request_context)
-
-scope = container.create_scope()
-context1 = scope.resolve(RequestContext)
-context2 = scope.resolve(RequestContext)
-assert context1 is context2  # Same instance within scope
+with container.create_scope() as scope:
+    a = scope.resolve(UnitOfWork)
+    b = scope.resolve(UnitOfWork)
+    assert a.session is b.session  # same DbSession within the scope
 ```
 
-### Instance Registration
+For the FastAPI wiring (container at startup, one scope per request) see
+[Recipes](./recipes.md) and [`examples/fastapi_app.py`](../examples/fastapi_app.py).
+For async resources that must be opened and closed around a request, see
+[Async](./async.md).
 
-You can register an already created instance.
+## Resolving every implementation
+
+Register the same key more than once and `resolve_all` returns all of them, in
+registration order. This is how you build plugin lists, event handlers, or
+middleware pipelines.
+
 ```python
-config = ConfigurationManager()
-container.add_instance(ConfigurationManager, config)
+container.add_transient(Notifier, EmailNotifier)
+container.add_transient(Notifier, SmsNotifier)
 
-resolved_config = container.resolve(ConfigurationManager)
-assert config is resolved_config  # Same instances
+for notifier in container.resolve_all(Notifier):
+    notifier.send("hi")
 ```
 
-### Resolving Dependencies
+More patterns: [Resolving multiple implementations](./resolve-all.md).
 
-#### Resolving Single Instances:
-Retrieve an instance of a registered service.
+## Named registrations
+
+When you need two implementations of the same type side by side, give them
+names and resolve by name.
+
 ```python
-service = container.resolve(MyService)
+container.add_singleton(Database, PrimaryDatabase, name="primary")
+container.add_singleton(Database, ReplicaDatabase, name="replica")
+
+replica = container.resolve(Database, name="replica")
 ```
 
-#### Resolving Multiple Instances
-If you have multiple implementations registered, you can resolve all of them.
+## Optional dependencies
+
+A parameter typed `Optional[...]` (or with a default) resolves to `None` (or the
+default) when nothing is registered for it, instead of raising.
+
 ```python
-class NotificationService:
-    pass
+class DataService:
+    def __init__(self, cache: Optional[Cache] = None):
+        self.cache = cache
 
-class EmailNotificationService(NotificationService):
-    pass
 
-class SMSNotificationService(NotificationService):
-    pass
-
-container.add_transient(NotificationService, EmailNotificationService)
-container.add_transient(NotificationService, SMSNotificationService)
-
-services = container.resolve_all(NotificationService)
-for service in services:
-    service.notify("Hello!")
+container.add_transient(DataService)
+container.resolve(DataService).cache  # None until a Cache is registered
 ```
 
-### Property Injection
+## Property injection
 
-Use the @inject decorator to inject dependencies into properties.
+Constructor injection covers most cases. When you can't change a constructor —
+a framework base class, for example — declare the dependency as an `@inject`
+method and read it as an attribute.
+
 ```python
 from injex import inject
 
-class Logger:
-    def log(self, message):
-        print(message)
 
 class Application:
     @inject
     def logger(self) -> Logger:
-        pass
+        ...
 
-    def run(self):
-        self.logger.log("Application is running.")
-
-container.add_singleton(Logger)
-container.add_transient(Application)
-
-app = container.resolve(Application)
-app.run()  # Output: Application is running.
+    def run(self) -> None:
+        self.logger.info("starting")
 ```
 
-### Named Registrations
+Property injection falls off the compiled fast path, so prefer constructors when
+you have the choice.
 
-Register multiple implementations under different names.
-```python
-class DatabaseService:
-    pass
+## Validation
 
-class MySQLDatabaseService(DatabaseService):
-    pass
-
-class PostgreSQLDatabaseService(DatabaseService):
-    pass
-
-container.add_singleton(DatabaseService, MySQLDatabaseService, name="mysql")
-container.add_singleton(DatabaseService, PostgreSQLDatabaseService, name="postgresql")
-
-mysql_service = container.resolve(DatabaseService, name="mysql")
-postgresql_service = container.resolve(DatabaseService, name="postgresql")
-```
-
-### Optional Dependencies
-
-Handle optional dependencies using Optional from the typing module.
-```python
-from typing import Optional
-
-class CacheService:
-    pass
-
-class DataService:
-    def __init__(self, cache: Optional[CacheService] = None):
-        self.cache = cache
-
-container.add_transient(DataService)
-
-data_service = container.resolve(DataService)
-assert data_service.cache is None  # CacheService was not registered
-```
-
-### Test Overrides
-
-Use `override()` when a test needs a fake implementation without changing the
-application container permanently.
+`assert_valid()` checks the whole graph — missing registrations, missing
+annotations, cycles — without constructing anything. Run it at startup or in a
+test so wiring mistakes fail immediately instead of on the first request.
 
 ```python
-from injex import Container
-
-
-class PaymentGateway:
-    def charge(self, amount: int) -> str:
-        return "real-payment-id"
-
-
-class FakePaymentGateway:
-    def __init__(self):
-        self.charges = []
-
-    def charge(self, amount: int) -> str:
-        self.charges.append(amount)
-        return "test-payment-id"
-
-
-class Checkout:
-    def __init__(self, payments: PaymentGateway):
-        self.payments = payments
-
-    def pay(self, amount: int) -> str:
-        return self.payments.charge(amount)
-
-
-container = Container()
-container.add_singleton(PaymentGateway)
-container.add_transient(Checkout)
-
-fake_payments = FakePaymentGateway()
-
-with container.override(PaymentGateway, instance=fake_payments):
-    checkout = container.resolve(Checkout)
-    assert checkout.pay(1999) == "test-payment-id"
-
-assert fake_payments.charges == [1999]
-```
-
-The original registration is restored when the context exits. Existing scoped
-instances are not rewritten, so create scopes inside the override block when the
-test uses scoped services.
-
-### Container Validation
-
-Use `validate()` or `assert_valid()` to catch wiring errors before the app starts.
-Validation inspects constructors, factories, and injected properties without
-creating service instances.
-
-```python
-from injex import Container
-
-
-class Settings:
-    pass
-
-
-class ApiClient:
-    def __init__(self, settings: Settings):
-        self.settings = settings
-
-
-container = Container()
-container.add_singleton(Settings)
-container.add_transient(ApiClient)
-
 container.assert_valid()
 ```
 
-When you want to format errors yourself, use `validate()`:
+Use `validate()` if you want the list of problems to format yourself. Details and
+the exact rules are in [Container validation](./validation.md).
+
+## Overrides in tests
+
+`override()` swaps a registration inside a `with` block and restores it on exit,
+so a test can inject a fake without touching the production container.
 
 ```python
-for error in container.validate():
-    print(error)
+fake = FakePaymentGateway()
+with container.override(PaymentGateway, instance=fake):
+    container.resolve(Checkout).pay(1999)
+assert fake.charges == [1999]
 ```
 
-Validation reports missing type annotations, missing required registrations, and
-dependency cycles. Optional dependencies and dependencies with default values are
-accepted when no registration exists.
+Existing scoped instances are not rewritten, so open scopes inside the override
+block when a test exercises scoped services.
 
-## Advanced Topics
+## Cycles
 
-### Scopes and Scoped Services
-Scopes allow you to define a boundary within which scoped services are shared. This is particularly useful in web applications where you might want to share certain services within a single request but not across different requests.
+If two services depend on each other, resolving raises
+`CyclicDependencyException` rather than recursing forever:
+
 ```python
-class RequestScopedService:
-    pass
+class A:
+    def __init__(self, b: "B"): ...
 
-container.add_scoped(RequestScopedService)
 
-# Simulating two different requests
-scope1 = container.create_scope()
-scope2 = container.create_scope()
+class B:
+    def __init__(self, a: "A"): ...
 
-service1 = scope1.resolve(RequestScopedService)
-service2 = scope1.resolve(RequestScopedService)
-service3 = scope2.resolve(RequestScopedService)
 
-assert service1 is service2  # Same instance within scope1
-assert service1 is not service3  # Different instances across scopes
+container.add_transient(A)
+container.add_transient(B)
+container.resolve(A)  # CyclicDependencyException
 ```
 
-### Cyclic Dependencies
-Injex detects cyclic dependencies and raises a CyclicDependencyException to prevent infinite loops.
-```python
-class ServiceA:
-    def __init__(self, service_b: "ServiceB"):
-        self.service_b = service_b
+`assert_valid()` reports the same cycle before you ever resolve.
 
-class ServiceB:
-    def __init__(self, service_a: "ServiceA"):
-        self.service_a = service_a
+## A larger example: a mediator
 
-container.add_transient(ServiceA)
-container.add_transient(ServiceB)
-
-try:
-    container.resolve(ServiceA)
-except CyclicDependencyException as e:
-    print(f"Cyclic dependency detected: {e}")
-```
-
-### Error Handling
-
-Injex provides specific exceptions to help you identify issues.
-
-* `ServiceNotRegisteredException`: Thrown when trying to resolve an unregistered service.
-* `CyclicDependencyException`: Thrown when a cyclic dependency is detected.
-* `MissingTypeAnnotationException`: Thrown when a parameter lacks a type annotation.
-* `InvalidLifestyleException`: Thrown when an invalid lifestyle is specified.
-
-Example:
-```python
-try:
-    container.resolve(UnregisteredService)
-except ServiceNotRegisteredException as e:
-    print(f"Service not registered: {e}")
-```
-
-## Real-World Examples
-
-Building a Mediator with Pipeline Behaviors
-
-A mediator pattern allows you to decouple the sending and handling of requests. Combining this with pipeline behaviors enables you to add cross-cutting concerns like logging, validation, and authorization.
+This ties the pieces together — `resolve_all` for the behavior pipeline, an
+injected container, and a singleton composing transient behaviors around a
+handler. A mediator decouples sending a request from handling it; behaviors add
+cross-cutting concerns (logging, auth) without the handler knowing.
 
 ```python
 from abc import ABC, abstractmethod
@@ -393,7 +245,6 @@ class Handler(ABC):
     def handle(self, request: Request) -> str: ...
 
 
-# A behavior wraps the handler to add a cross-cutting concern.
 class Behavior(ABC):
     @abstractmethod
     def process(self, request: Request, call_next: Callable[[], str]) -> str: ...
@@ -401,104 +252,44 @@ class Behavior(ABC):
 
 class LoggingBehavior(Behavior):
     def process(self, request: Request, call_next: Callable[[], str]) -> str:
-        print(f"Logging: {request.data}")
-        return call_next()
-
-
-class AuthorizationBehavior(Behavior):
-    def process(self, request: Request, call_next: Callable[[], str]) -> str:
-        print("Authorizing request")
+        print(f"log: {request.data}")
         return call_next()
 
 
 class EchoHandler(Handler):
     def handle(self, request: Request) -> str:
-        print(f"Handling: {request.data}")
-        return f"Processed: {request.data}"
+        return f"processed: {request.data}"
 
 
 class Mediator:
-    def __init__(self, container):  # an unannotated `container` is injected by Injex
+    def __init__(self, container):  # an unannotated `container` parameter is the container itself
         self.container = container
 
     def send(self, request: Request) -> str:
-        behaviors = self.container.resolve_all(Behavior)
         handler = self.container.resolve(Handler)
-
-        def call() -> str:
-            return handler.handle(request)
-
-        # Wrap each behavior around the handler; the first registered runs outermost.
-        for behavior in reversed(behaviors):
-            call_next = call
-
-            def call(behavior=behavior, call_next=call_next) -> str:
-                return behavior.process(request, call_next)
-
+        call = lambda: handler.handle(request)
+        # Wrap each behavior around the handler; first registered runs outermost.
+        for behavior in reversed(self.container.resolve_all(Behavior)):
+            call = lambda b=behavior, nxt=call: b.process(request, nxt)
         return call()
 
 
 container = Container()
 container.add_transient(Behavior, LoggingBehavior)
-container.add_transient(Behavior, AuthorizationBehavior)
 container.add_transient(Handler, EchoHandler)
 container.add_singleton(Mediator)
 
-mediator = container.resolve(Mediator)
-print(mediator.send(Request("Important Task")))
+print(container.resolve(Mediator).send(Request("task")))
 ```
 
-Output:
+## Errors
 
-```text
-Logging: Important Task
-Authorizing request
-Handling: Important Task
-Processed: Important Task
-```
+Every Injex exception subclasses `DIException`, so you can catch the specific one
+or all of them. The full list and when each is raised is in the
+[API reference](./api.md#exceptions).
 
-This shows `resolve_all()` returning every registered `Behavior`, an injected
-container (the unannotated `container` parameter), and a singleton `Mediator`
-composing transient behaviors around the handler.
+## Where to go next
 
-### Creating an API Service with Database Integration
-
-Integrate Injex with a web framework like FastAPI to manage dependencies such as database connections and services.
-
-```python
-from fastapi import FastAPI, Depends
-from injex import Container
-
-app = FastAPI()
-container = Container()
-
-# Services
-class DatabaseConnection:
-    def __init__(self):
-        self.connection = self.connect_to_db()
-
-    def connect_to_db(self):
-        # Database connection logic
-        pass
-
-class UserService:
-    def __init__(self, db: DatabaseConnection):
-        self.db = db
-
-    def get_users(self):
-        # Use self.db to fetch users
-        return [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]
-
-# Configure DI
-container.add_scoped(DatabaseConnection)
-container.add_transient(UserService)
-
-# Dependency Injection in FastAPI
-def get_user_service() -> UserService:
-    scope = container.create_scope()
-    return scope.resolve(UserService)
-
-@app.get("/users")
-def list_users(service: UserService = Depends(get_user_service)):
-    return service.get_users()
-```
+- [Recipes](./recipes.md) — FastAPI, workers, CLIs, test boundaries.
+- [Async](./async.md) — async factories and resource lifecycles.
+- [Why Injex](./why-injex.md) — when to reach for it and when not to.


### PR DESCRIPTION
A pass over the docs for anything that read generated rather than written. The tutorial was the outlier.

## Tutorial (`docs/tutorial.md`, 505 → 295 lines)
- Dropped the textbook structure (Singleton/Transient/Scoped and Singleton/Transient/Scoped-factory section triplets) and the comment-narrated `assert ... # Same instance` style.
- Reframed as a problem-first walkthrough: the core register/resolve loop, then each feature with a one-line reason you'd reach for it.
- Stopped duplicating the dedicated guides — validation, recipes, async, and resolve-all are linked instead of re-explained.
- **Fixed the FastAPI example.** It built the container per request and opened a scope inside the dependency, which contradicts the lifespan pattern in `recipes.md`. Now points at the recipe and `examples/fastapi_app.py`.
- Replaced the incomplete hand-maintained exception list with a link to the API reference (which lists all of them).

## Changelog
- Folded the two overlapping async entries in the unreleased 1.5.0 section into one and trimmed implementation-detail prose to what a reader evaluating the release actually needs.

No code changes. Verified the rest of the repo and site separately (parallel review): no marketing filler, consistent benchmark numbers, valid links — the tutorial was the one weak page.