### PR TITLE
Build singletons once under concurrent resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project uses semantic versioning.
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-06-19
+
+### Fixed
+
+- Thread-safe singleton construction. Concurrent first resolves of the same
+  singleton could each build it, handing different threads different instances.
+  Construction is now guarded by a reentrant lock with a lock-free fast path, so
+  a singleton is built once; the warm resolve path is unchanged.
+
 ## [1.5.0] - 2026-06-19
 
 ### Changed

--- a/injex/container.py
+++ b/injex/container.py
@@ -133,6 +133,7 @@ class Container:
         "_resolving_local",
         "_async_resource_keys",
         "_async_creators",
+        "_singleton_lock",
     )
 
     def __init__(self) -> None:
@@ -140,6 +141,10 @@ class Container:
             tuple[type | str, str | None], list[Registration]
         ] = {}
         self._singletons: dict[Any, Any] = {}
+        # Guards first-time singleton construction so concurrent resolves build a
+        # singleton once. Reentrant for nested singleton dependencies; only taken
+        # on a cache miss, so the warm path stays lock-free.
+        self._singleton_lock = threading.RLock()
         # Per-thread in-progress set for cycle detection on the interpreted sync
         # path. Thread-local so concurrent resolves (e.g. a threaded web server)
         # never see each other's in-progress types. The async path uses its own
@@ -978,19 +983,24 @@ class Container:
             sentinel = object()
             cached_instance = [sentinel]
             singletons = self._singletons
+            lock = self._singleton_lock
 
             def create_singleton(scope: Scope) -> Any:
                 instance = cached_instance[0]
                 if instance is not sentinel:
                     return instance
-                if instance_key in singletons:
-                    instance = singletons[instance_key]
+                with lock:
+                    instance = cached_instance[0]
+                    if instance is not sentinel:
+                        return instance
+                    if instance_key in singletons:
+                        instance = singletons[instance_key]
+                        cached_instance[0] = instance
+                        return instance
+                    instance = create_raw(scope)
+                    singletons[instance_key] = instance
                     cached_instance[0] = instance
                     return instance
-                instance = create_raw(scope)
-                singletons[instance_key] = instance
-                cached_instance[0] = instance
-                return instance
 
             return create_singleton, needs_scope
 
@@ -1006,6 +1016,22 @@ class Container:
             return create_scoped, True
 
         return None
+
+    def _get_or_create_singleton(
+        self,
+        instance_key: Any,
+        registration: Registration,
+        scope: Scope,
+    ) -> Any:
+        # Double-checked under the lock: a concurrent first resolve must build
+        # the singleton once and every caller must get that one instance.
+        with self._singleton_lock:
+            existing = self._singletons.get(instance_key, _MISSING)
+            if existing is not _MISSING:
+                return existing
+            instance = self._create_instance_from_registration(registration, scope)
+            self._singletons[instance_key] = instance
+            return instance
 
     def _get_instance_from_registration(
         self,
@@ -1024,11 +1050,10 @@ class Container:
         lifestyle = registration.lifestyle
 
         if lifestyle == LifeStyle.SINGLETON:
-            if instance_key in self._singletons:
-                return self._singletons[instance_key]
-            instance = self._create_instance_from_registration(registration, scope)
-            self._singletons[instance_key] = instance
-            return instance
+            existing = self._singletons.get(instance_key, _MISSING)
+            if existing is not _MISSING:
+                return existing
+            return self._get_or_create_singleton(instance_key, registration, scope)
         elif lifestyle == LifeStyle.SCOPED:
             if instance_key in scope._scoped_instances:
                 return scope._scoped_instances[instance_key]
@@ -1113,11 +1138,10 @@ class Container:
             instance_key = (key, registration)
             lifestyle = registration.lifestyle
             if lifestyle == LifeStyle.SINGLETON:
-                if instance_key in self._singletons:
-                    return self._singletons[instance_key]
-                instance = self._create_instance_from_registration(registration, scope)
-                self._singletons[instance_key] = instance
-                return instance
+                existing = self._singletons.get(instance_key, _MISSING)
+                if existing is not _MISSING:
+                    return existing
+                return self._get_or_create_singleton(instance_key, registration, scope)
             if lifestyle == LifeStyle.SCOPED:
                 if instance_key in scope._scoped_instances:
                     return scope._scoped_instances[instance_key]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "injex"
-version = "1.5.0"
+version = "1.5.1"
 authors = [{name = "vshulcz", email = "vshulcz@gmail.com"}]
 description = "Tiny typed dependency injection container for Python"
 readme = "README.md"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,12 +1,12 @@
-"""Thread-safety of the interpreted sync resolve path.
+"""Thread-safety of the sync resolve path.
 
-The compiled fast path never touches shared cycle-guard state, but property
-injection / factory graphs fall to the interpreted path, which used to share a
-single in-progress set across threads and produced spurious cycle errors. The
-guard is now per-thread; this pins that down.
+Two properties are pinned here: the interpreted path's cycle guard is per-thread
+(it used to share one in-progress set and raise spurious cycle errors), and a
+singleton is constructed exactly once even when threads first resolve it together.
 """
 
 import threading
+import time
 
 from injex import Container, inject
 
@@ -41,3 +41,37 @@ def test_no_false_cycles_under_concurrent_interpreted_resolve():
         t.join()
 
     assert errors == [], f"{len(errors)} spurious errors: {set(errors)}"
+
+
+def test_singleton_built_once_under_concurrent_first_resolve():
+    builds = []
+    builds_lock = threading.Lock()
+
+    class Settings:
+        pass
+
+    class Pool:
+        def __init__(self, settings: Settings):
+            with builds_lock:
+                builds.append(1)
+            time.sleep(0.002)  # widen the race window
+
+    c = Container()
+    c.add_singleton(Settings)
+    c.add_singleton(Pool)  # depends on another singleton: exercises reentrancy
+
+    barrier = threading.Barrier(16)
+    seen: list[int] = []
+
+    def worker() -> None:
+        barrier.wait()  # all threads hit the cold cache together
+        seen.append(id(c.resolve(Pool)))
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(builds) == 1, f"singleton built {sum(builds)} times"
+    assert len(set(seen)) == 1, "threads received different singleton instances"

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "injex"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Bug
Concurrent first resolves of the same singleton each built it and handed different threads different instances — the exact multithreaded-server/worker case the container targets. Repro (16 threads, slow `__init__`): 16 constructions, 16 distinct instances.

## Fix
First-time construction goes through a reentrant lock with a lock-free fast path (read the cache first; only miss takes the lock, then double-checks). A singleton now builds once and every caller gets it. Reentrant so a singleton depending on another singleton doesn't deadlock. Warm resolves are unchanged — the lock is never touched once cached (and inlined-constant singletons never reach it).

Adds a concurrency regression test (16 threads, barrier-synced cold start). 1.5.0 was affected, so this is 1.5.1.

mypy + ruff clean; 119 passed / 3 skipped; warm-path resolve unchanged (~0.28 µs/op locally).