### PR TITLE
Inject named registrations via Annotated[T, Named(...)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project uses semantic versioning.
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-06-19
+
+### Added
+
+- Inject a named registration into a constructor with
+  `Annotated[T, Named("primary")]`. Previously a named registration could only be
+  reached through `resolve(T, name="primary")`; now it can be a constructor
+  dependency, and `validate()` checks it like any other.
+- `Scope` is a context manager: `with container.create_scope() as scope: ...`
+  drops the scope's per-scope instances on exit.
+
 ## [1.5.1] - 2026-06-19
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,11 @@ If `implementation` is omitted, Injex uses `interface` as the concrete class.
 
 - `resolve(interface, name=None)` returns one service instance.
 - `resolve_all(interface, name=None)` returns all matching registrations.
-- `create_scope()` creates a scope for scoped services.
+- `create_scope()` creates a scope for scoped services. Usable as a context
+  manager (`with container.create_scope() as scope:`).
+
+To inject a named registration into a constructor, annotate the parameter:
+`Annotated[T, Named("primary")]` (import `Named` from `injex`).
 
 ### Overrides
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -135,6 +135,19 @@ container.add_singleton(Database, ReplicaDatabase, name="replica")
 replica = container.resolve(Database, name="replica")
 ```
 
+To inject a specific one into a constructor, mark the parameter with
+`Annotated[T, Named(...)]`:
+
+```python
+from typing import Annotated
+from injex import Named
+
+
+class ReportJob:
+    def __init__(self, db: Annotated[Database, Named("replica")]):
+        self.db = db  # gets ReplicaDatabase
+```
+
 ## Optional dependencies
 
 A parameter typed `Optional[...]` (or with a default) resolves to `None` (or the

--- a/injex/__init__.py
+++ b/injex/__init__.py
@@ -16,6 +16,10 @@ from .errors import (
     _describe_service as _describe_service,
 )
 from .planning import (
+    Named,
+    inject,
+)
+from .planning import (
     _cached_callable_plan as _cached_callable_plan,
 )
 from .planning import (
@@ -35,9 +39,6 @@ from .planning import (
 )
 from .planning import (
     _make_fast_raw_creator as _make_fast_raw_creator,
-)
-from .planning import (
-    inject,
 )
 from .planning import (
     is_injectable as is_injectable,
@@ -65,6 +66,7 @@ __all__ = [
     "InvalidLifestyleException",
     "LifeStyle",
     "MissingTypeAnnotationException",
+    "Named",
     "PropertyInjectionException",
     "Scope",
     "ServiceNotRegisteredException",

--- a/injex/container.py
+++ b/injex/container.py
@@ -1,16 +1,12 @@
 import asyncio
 import inspect
 import threading
-import types
 from collections.abc import Callable
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import (
     Any,
     TypeVar,
-    Union,
     cast,
-    get_args,
-    get_origin,
     overload,
 )
 
@@ -37,6 +33,7 @@ from .planning import (
     _make_constant_creator,
     _make_fast_raw_creator,
     _none_creator,
+    _normalize_dependency_type,
     _ServicePlan,
 )
 from .registry import LifeStyle, OverrideContext, Registration, RegistrationType
@@ -56,6 +53,13 @@ class Scope:
     def __init__(self, container: "Container"):
         self.container = container
         self._scoped_instances: dict[Any, Any] = {}
+
+    def __enter__(self) -> "Scope":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        # Drop per-scope instances so they aren't held past the block.
+        self._scoped_instances.clear()
 
     @overload
     def resolve(self, interface: type[T], name: str | None = None) -> T: ...
@@ -561,16 +565,12 @@ class Container:
         dependency_name: str,
         has_default: bool = False,
     ) -> list[ValidationError]:
-        is_optional = False
-        origin = get_origin(dependency_type)
-        if origin in (Union, types.UnionType):
-            args = get_args(dependency_type)
-            if type(None) in args:
-                is_optional = True
-                non_none_args = [arg for arg in args if arg is not type(None)]
-                dependency_type = non_none_args[0] if non_none_args else Any
+        dependency_type, is_optional, dep_name = _normalize_dependency_type(
+            dependency_type
+        )
 
-        dependency_key = self._get_validation_key(dependency_type)
+        base_key = self._get_validation_key(dependency_type)
+        dependency_key = (base_key[0], dep_name)
         registrations = self._registrations.get(dependency_key, [])
         if not registrations:
             if is_optional or has_default:

--- a/injex/planning.py
+++ b/injex/planning.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 from typing import (
+    Annotated,
     Any,
     Union,
     cast,
@@ -11,6 +12,17 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+
+
+@dataclass(frozen=True)
+class Named:
+    """Marker for an `Annotated` dependency that selects a named registration.
+
+    ``def __init__(self, db: Annotated[Database, Named("primary")]): ...``
+    injects the registration made with ``name="primary"``.
+    """
+
+    name: str
 
 
 def inject(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -33,7 +45,8 @@ def _cached_parameters(
 
 @cache
 def _cached_type_hints(func: Callable[..., Any]) -> dict[str, Any]:
-    return get_type_hints(func)
+    # include_extras keeps Annotated metadata so Named(...) markers survive.
+    return get_type_hints(func, include_extras=True)
 
 
 def _get_parameters(
@@ -91,14 +104,26 @@ class _FactoryPlan:
     dependencies: tuple[_DependencyPlan, ...]
 
 
-def _normalize_dependency_type(dependency_type: Any) -> tuple[Any, bool]:
+def _unwrap_annotated(dependency_type: Any) -> tuple[Any, str | None]:
+    """Strip an ``Annotated`` wrapper, returning the type and any ``Named``."""
+    if get_origin(dependency_type) is Annotated:
+        args = get_args(dependency_type)
+        name = next((m.name for m in args[1:] if isinstance(m, Named)), None)
+        return args[0], name
+    return dependency_type, None
+
+
+def _normalize_dependency_type(dependency_type: Any) -> tuple[Any, bool, str | None]:
+    dependency_type, name = _unwrap_annotated(dependency_type)
     origin = get_origin(dependency_type)
     if origin in (Union, types.UnionType):
         args = get_args(dependency_type)
         if type(None) in args:
             non_none_args = [arg for arg in args if arg is not type(None)]
-            return (non_none_args[0] if non_none_args else Any, True)
-    return dependency_type, False
+            inner = non_none_args[0] if non_none_args else Any
+            inner, inner_name = _unwrap_annotated(inner)
+            return inner, True, (name or inner_name)
+    return dependency_type, False, name
 
 
 @cache
@@ -131,10 +156,12 @@ def _cached_callable_plan(
             continue
 
         dependency_type = type_hints.get(name, param.annotation)
-        dependency_type, is_optional = _normalize_dependency_type(dependency_type)
+        dependency_type, is_optional, dep_name = _normalize_dependency_type(
+            dependency_type
+        )
         dependency_key = None
         if dependency_type != inspect.Parameter.empty:
-            dependency_key = (dependency_type, None)
+            dependency_key = (dependency_type, dep_name)
         dependencies.append(
             _DependencyPlan(
                 name=name,
@@ -179,10 +206,12 @@ def _get_callable_plan(
                 continue
 
             dependency_type = type_hints.get(name, param.annotation)
-            dependency_type, is_optional = _normalize_dependency_type(dependency_type)
+            dependency_type, is_optional, dep_name = _normalize_dependency_type(
+                dependency_type
+            )
             dependency_key = None
             if dependency_type != inspect.Parameter.empty:
-                dependency_key = (dependency_type, None)
+                dependency_key = (dependency_type, dep_name)
             dependencies.append(
                 _DependencyPlan(
                     name=name,
@@ -203,12 +232,14 @@ def _cached_property_dependencies(cls: type) -> tuple[_DependencyPlan, ...]:
         type_hints = _cached_type_hints(attr)
         dependency_type = type_hints.get("return")
         if dependency_type is not None and dependency_type != inspect.Parameter.empty:
-            dependency_type, is_optional = _normalize_dependency_type(dependency_type)
+            dependency_type, is_optional, dep_name = _normalize_dependency_type(
+                dependency_type
+            )
             dependencies.append(
                 _DependencyPlan(
                     name=name,
                     dependency_type=dependency_type,
-                    dependency_key=(dependency_type, None),
+                    dependency_key=(dependency_type, dep_name),
                     has_default=False,
                     default=inspect.Parameter.empty,
                     is_optional=is_optional,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "injex"
-version = "1.5.1"
+version = "1.6.0"
 authors = [{name = "vshulcz", email = "vshulcz@gmail.com"}]
 description = "Tiny typed dependency injection container for Python"
 readme = "README.md"

--- a/tests/test_named_injection.py
+++ b/tests/test_named_injection.py
@@ -1,0 +1,97 @@
+"""Injecting named registrations into constructors via Annotated[T, Named(...)]."""
+
+import asyncio
+from typing import Annotated
+
+from injex import Container, Named
+
+
+class DB:
+    pass
+
+
+class Primary(DB):
+    pass
+
+
+class Replica(DB):
+    pass
+
+
+def _two_db_container() -> Container:
+    c = Container()
+    c.add_singleton(DB, Primary, name="primary")
+    c.add_singleton(DB, Replica, name="replica")
+    return c
+
+
+def test_named_dependency_selects_registration():
+    class Service:
+        def __init__(self, db: Annotated[DB, Named("replica")]):
+            self.db = db
+
+    c = _two_db_container()
+    c.add_transient(Service)
+    assert isinstance(c.resolve(Service).db, Replica)
+
+
+def test_two_named_dependencies_in_one_constructor():
+    class Service:
+        def __init__(
+            self,
+            read: Annotated[DB, Named("replica")],
+            write: Annotated[DB, Named("primary")],
+        ):
+            self.read = read
+            self.write = write
+
+    c = _two_db_container()
+    c.add_transient(Service)
+    s = c.resolve(Service)
+    assert isinstance(s.read, Replica)
+    assert isinstance(s.write, Primary)
+
+
+def test_named_dependency_in_scope_and_async():
+    class Service:
+        def __init__(self, db: Annotated[DB, Named("primary")]):
+            self.db = db
+
+    c = _two_db_container()
+    c.add_transient(Service)
+
+    with c.create_scope() as scope:
+        assert isinstance(scope.resolve(Service).db, Primary)
+
+    assert isinstance(asyncio.run(c.aresolve(Service)).db, Primary)
+
+
+def test_optional_named_dependency_missing_is_none():
+    class Service:
+        def __init__(self, db: Annotated[DB, Named("missing")] | None = None):
+            self.db = db
+
+    c = _two_db_container()
+    c.add_transient(Service)
+    assert c.resolve(Service).db is None
+
+
+def test_validate_accepts_registered_named_dependency():
+    class Service:
+        def __init__(self, db: Annotated[DB, Named("primary")]):
+            self.db = db
+
+    c = _two_db_container()
+    c.add_transient(Service)
+    assert c.validate() == []
+
+
+def test_validate_reports_missing_named_dependency():
+    class Service:
+        def __init__(self, db: Annotated[DB, Named("nope")]):
+            self.db = db
+
+    c = _two_db_container()
+    c.add_transient(Service)
+    errors = c.validate()
+    assert len(errors) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ wheels = [
 
 [[package]]
 name = "injex"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Feature
A named registration (`add_singleton(DB, Replica, name="replica")`) could only be reached with an explicit `resolve(DB, name="replica")` — it couldn't be a constructor dependency. Now it can:

```python
from typing import Annotated
from injex import Named

class ReportJob:
    def __init__(self, db: Annotated[Database, Named("replica")]):
        ...
```

Works through the compiled flat path, scopes, and `aresolve()`; `validate()` checks it like any other dependency. `Optional[Annotated[T, Named(...)]]` resolves to `None` when absent.

Implementation: type hints are read with `include_extras=True` and the `Named` marker is pulled out of the `Annotated` metadata into the dependency key `(T, name)`. All parsing happens at plan-build time (cached), so the resolve hot path is unchanged.

Also makes `Scope` a context manager (`with container.create_scope() as scope:`), which the docs already showed.

mypy strict + ruff clean; 126 passed / 3 skipped. New tests in `tests/test_named_injection.py`. 1.6.0 (adds features).