### PR TITLE
Clearer resolution errors; dedupe validate() output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project uses semantic versioning.
 - `Scope` is a context manager: `with container.create_scope() as scope: ...`
   drops the scope's per-scope instances on exit.
 
+### Changed
+
+- Clearer resolution errors. A missing dependency now reads
+  `Service for interface 'DB' is not registered. It is required by Repo.db.`
+  instead of printing the raw class repr with no context. `validate()` no longer
+  repeats the same error once per root that shares a dependency.
+
 ## [1.5.1] - 2026-06-19
 
 ### Fixed

--- a/injex/container.py
+++ b/injex/container.py
@@ -393,9 +393,16 @@ class Container:
     def validate(self) -> list[ValidationError]:
         """Validate registered dependency graphs without creating service instances."""
         errors: list[ValidationError] = []
+        seen: set[str] = set()
         for key, registrations in self._registrations.items():
             for registration in registrations:
-                errors.extend(self._validate_registration(key, registration, []))
+                for error in self._validate_registration(key, registration, []):
+                    # A shared dependency is reached from several roots; report
+                    # each distinct problem once.
+                    marker = str(error)
+                    if marker not in seen:
+                        seen.add(marker)
+                        errors.append(error)
         return errors
 
     def assert_valid(self) -> None:
@@ -421,7 +428,7 @@ class Container:
         key = (interface, name)
         registrations = self._registrations.get(key)
         if not registrations:
-            interface_name = f"{interface}"
+            interface_name = _describe_service(interface)
             if name is not None:
                 interface_name += f" with name '{name}'"
             raise ServiceNotRegisteredException(interface_name)
@@ -1118,6 +1125,18 @@ class Container:
         registration.plan = plan
         return plan
 
+    @staticmethod
+    def _describe_owner(owner: Any, name: str) -> str:
+        return f"{getattr(owner, '__name__', owner)}.{name}"
+
+    @staticmethod
+    def _describe_dependency(dependency_plan: _DependencyPlan) -> str:
+        detail = _describe_service(dependency_plan.dependency_type)
+        key = dependency_plan.dependency_key
+        if key is not None and key[1] is not None:
+            detail += f" named '{key[1]}'"
+        return detail
+
     def _resolve_dependency_plan(
         self, dependency_plan: _DependencyPlan, scope: Scope, owner: type
     ) -> Any:
@@ -1160,7 +1179,10 @@ class Container:
             return dependency_plan.default
         if dependency_plan.is_optional:
             return None
-        raise ServiceNotRegisteredException(f"{dependency_type}")
+        raise ServiceNotRegisteredException(
+            self._describe_dependency(dependency_plan),
+            required_by=self._describe_owner(owner, dependency_plan.name),
+        )
 
     def _invoke_factory_registration(
         self, registration: Registration, scope: Scope
@@ -1264,7 +1286,7 @@ class Container:
         key = (interface, name)
         registrations = self._registrations.get(key)
         if not registrations:
-            interface_name = f"{interface}"
+            interface_name = _describe_service(interface)
             if name is not None:
                 interface_name += f" with name '{name}'"
             raise ServiceNotRegisteredException(interface_name)
@@ -1444,7 +1466,10 @@ class Container:
             return dependency_plan.default
         if dependency_plan.is_optional:
             return None
-        raise ServiceNotRegisteredException(f"{dependency_type}")
+        raise ServiceNotRegisteredException(
+            self._describe_dependency(dependency_plan),
+            required_by=self._describe_owner(owner, dependency_plan.name),
+        )
 
     async def _ainject_property_dependencies(
         self,

--- a/injex/errors.py
+++ b/injex/errors.py
@@ -6,15 +6,18 @@ class DIException(Exception):
 
 
 class ServiceNotRegisteredException(DIException):
-    def __init__(self, interface_description: str):
-        super().__init__(
-            f"Service for interface '{interface_description}' is not registered."
-        )
+    def __init__(
+        self, interface_description: str, required_by: str | None = None
+    ) -> None:
+        message = f"Service for interface '{interface_description}' is not registered."
+        if required_by is not None:
+            message += f" It is required by {required_by}."
+        super().__init__(message)
 
 
 class CyclicDependencyException(DIException):
     def __init__(self, cls: type):
-        super().__init__(f"Cyclic dependency detected: {cls}.")
+        super().__init__(f"Cyclic dependency detected: {_describe_service(cls)}.")
 
 
 class MissingTypeAnnotationException(DIException):

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -424,7 +424,9 @@ class TestContainer(unittest.TestCase):
 
         with self.assertRaises(ServiceNotRegisteredException) as context:
             self.container.resolve(Consumer)
-        self.assertIn("Service for interface '<class", str(context.exception))
+        message = str(context.exception)
+        self.assertIn("DependencyUnregistered", message)
+        self.assertIn("Consumer.dependency", message)  # names the requiring site
 
     def test_cyclic_dependency_with_property_injection(self):
         self.container.register(ServiceA_prop_inj)

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -1,0 +1,61 @@
+"""Resolution errors should read clearly and validate() shouldn't repeat itself."""
+
+from injex import Container, ServiceNotRegisteredException
+
+
+class DB:
+    pass
+
+
+class Repo:
+    def __init__(self, db: DB):
+        self.db = db
+
+
+class RegisterUser:
+    def __init__(self, repo: Repo):
+        self.repo = repo
+
+
+def test_missing_dependency_names_clean_type_and_requiring_site():
+    c = Container()
+    c.add_transient(Repo)  # DB not registered
+    c.add_transient(RegisterUser)
+
+    try:
+        c.resolve(RegisterUser)
+    except ServiceNotRegisteredException as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected ServiceNotRegisteredException")
+
+    assert "'DB'" in message  # clean name, not "<class '...DB'>"
+    assert "<class" not in message
+    assert "Repo.db" in message  # points at who needed it
+
+
+def test_top_level_missing_uses_clean_name():
+    c = Container()
+    try:
+        c.resolve(DB)
+    except ServiceNotRegisteredException as exc:
+        assert "'DB'" in str(exc)
+        assert "<class" not in str(exc)
+    else:
+        raise AssertionError("expected ServiceNotRegisteredException")
+
+
+def test_validate_does_not_duplicate_shared_dependency_errors():
+    # Two roots both depend on Repo, which depends on the unregistered DB.
+    class OtherUser:
+        def __init__(self, repo: Repo):
+            self.repo = repo
+
+    c = Container()
+    c.add_transient(Repo)
+    c.add_transient(RegisterUser)
+    c.add_transient(OtherUser)
+
+    errors = c.validate()
+    messages = [str(e) for e in errors]
+    assert len(messages) == len(set(messages))  # no duplicates


### PR DESCRIPTION
Two DX papercuts found while exercising failures.

**Missing-dependency errors were unhelpful.** A nested miss printed `Service for interface '<class '__main__.DB'>' is not registered.` — raw repr, no hint about what needed it. Now: `Service for interface 'DB' is not registered. It is required by Repo.db.` on both the sync and async paths. Cyclic and top-level errors use the clean name too (`Named(...)` is included when relevant).

**validate() repeated itself.** A dependency shared by several roots produced the same error once per root. It's now reported once.

New tests in `tests/test_error_messages.py`; updated one test that pinned the old raw-repr message. mypy strict + ruff clean, 129 passed / 3 skipped.