### PR TITLE
docs: FastAPI route example (from #28) + credit contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,5 +228,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Thanks to [Muhammad Saqib Atif](https://github.com/msaqibatifj),
 [mahek](https://github.com/mahek56),
-[oppnc](https://github.com/oppnc), and
-[YuuGR1337](https://github.com/YuuGR1337) for improving Injex.
+[oppnc](https://github.com/oppnc),
+[YuuGR1337](https://github.com/YuuGR1337), and
+[ankitaparasher04](https://github.com/ankitaparasher04) for improving Injex.

--- a/docs/fastapi-depends.md
+++ b/docs/fastapi-depends.md
@@ -59,3 +59,20 @@ services.register_user.execute("ada@example.com")
 The rule of thumb: FastAPI adapts HTTP; the application owns service wiring.
 
 See also: [`examples/fastapi_lifespan.py`](../examples/fastapi_lifespan.py).
+
+## FastAPI route example
+
+Here is how to use the existing `get_register_user` dependency in a FastAPI route.
+
+```python
+from fastapi import APIRouter, Depends
+
+router = APIRouter()
+
+@router.post("/register")
+def register_user(
+    email: str,
+    use_case: RegisterUser = Depends(get_register_user),
+) -> int:
+    return use_case.execute(email)
+```


### PR DESCRIPTION
Lands @ankitaparasher04's FastAPI route recipe from #28, rebased onto current main. Their branch was based on the 1.4.0 release and had drifted into conflicts across 28 files, so I replayed just the recipe commit (authored by them) onto main and added the trailing newline that review asked for. Also credits them in the README.

Closes #23.