### PR TITLE
container.call() / acall(): inject dependencies into functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project uses semantic versioning.
 
 ### Added
 
+- `container.call(func, **overrides)` (and async `acall`) invoke a function with
+  its annotated parameters injected from the container, while `overrides` supplies
+  per-call values (a request, parsed args, a message). `acall` awaits async
+  dependencies and coroutine functions and finalizes async resources opened for
+  the call. This is the building block for wiring handlers, CLI commands, and
+  task consumers without turning them into classes.
 - Inject a named registration into a constructor with
   `Annotated[T, Named("primary")]`. Previously a named registration could only be
   reached through `resolve(T, name="primary")`; now it can be a constructor

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,9 @@ If `implementation` is omitted, Injex uses `interface` as the concrete class.
 
 - `resolve(interface, name=None)` returns one service instance.
 - `resolve_all(interface, name=None)` returns all matching registrations.
+- `call(func, **overrides)` calls `func`, injecting its annotated parameters;
+  values in `overrides` are passed as-is (a request, parsed args, a message).
+  `acall(...)` is the async counterpart.
 - `create_scope()` creates a scope for scoped services. Usable as a context
   manager (`with container.create_scope() as scope:`).
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -87,6 +87,25 @@ singleton.
 container.add_instance(Settings, load_settings())
 ```
 
+## Calling functions
+
+`resolve` builds objects; `call` invokes a function, filling its annotated
+parameters from the container. Pass the rest yourself — a request, parsed CLI
+args, a queue message. This is how you keep handlers free of wiring without
+turning them into classes.
+
+```python
+def register_user(email: str, use_case: RegisterUser) -> int:
+    return use_case.execute(email)
+
+
+container.call(register_user, email="ada@example.com")  # use_case is injected
+```
+
+`acall` is the async counterpart: it awaits async dependencies, awaits the
+function if it's a coroutine, and finalizes any async resources opened for the
+call when it returns.
+
 ## Scopes
 
 A scope is a boundary that scoped services live inside of — typically one web

--- a/injex/container.py
+++ b/injex/container.py
@@ -390,6 +390,29 @@ class Container:
         resources use ``async with container.ascope()`` instead."""
         return Scope(self)
 
+    def call(self, func: Callable[..., T], /, **overrides: Any) -> T:
+        """Call ``func``, injecting its annotated parameters from the container.
+
+        Parameters passed in ``overrides`` are used as-is instead of being
+        resolved, so a handler can receive both container services and
+        per-call values (a request, parsed args, a message)::
+
+            container.call(handle_request, request=req)
+        """
+        plan = _get_callable_plan(func)
+        scope = self.create_scope()
+        kwargs: dict[str, Any] = dict(overrides)
+        for dependency_plan in plan.dependencies:
+            if dependency_plan.name in overrides:
+                continue
+            if dependency_plan.inject_container:
+                kwargs[dependency_plan.name] = self
+            else:
+                kwargs[dependency_plan.name] = self._resolve_dependency_plan(
+                    dependency_plan, scope, func
+                )
+        return func(**kwargs)
+
     def validate(self) -> list[ValidationError]:
         """Validate registered dependency graphs without creating service instances."""
         errors: list[ValidationError] = []
@@ -1138,7 +1161,7 @@ class Container:
         return detail
 
     def _resolve_dependency_plan(
-        self, dependency_plan: _DependencyPlan, scope: Scope, owner: type
+        self, dependency_plan: _DependencyPlan, scope: Scope, owner: Any
     ) -> Any:
         if dependency_plan.inject_container:
             return self
@@ -1194,7 +1217,7 @@ class Container:
             raise AsyncResolutionRequiredException(factory)
         plan = self._get_factory_plan(registration)
         args = [
-            self._resolve_dependency_plan(dependency_plan, scope, factory)  # type: ignore[arg-type]
+            self._resolve_dependency_plan(dependency_plan, scope, factory)
             for dependency_plan in plan.dependencies
         ]
         return factory(*args)
@@ -1205,6 +1228,27 @@ class Container:
         """Open an async resolution scope. Use as ``async with``; async resources
         resolved inside are finalized when the block exits."""
         return AsyncScope(self)
+
+    async def acall(self, func: Callable[..., Any], /, **overrides: Any) -> Any:
+        """Async counterpart of :meth:`call`. Awaits async dependencies, awaits
+        ``func`` if it is a coroutine function, and finalizes any async resources
+        opened for the call when it returns."""
+        plan = _get_callable_plan(func)
+        async with self.ascope() as scope:
+            kwargs: dict[str, Any] = dict(overrides)
+            for dependency_plan in plan.dependencies:
+                if dependency_plan.name in overrides:
+                    continue
+                if dependency_plan.inject_container:
+                    kwargs[dependency_plan.name] = self
+                else:
+                    kwargs[dependency_plan.name] = await self._aresolve_dependency_plan(
+                        dependency_plan, scope, func, set()
+                    )
+            result = func(**kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
 
     @overload
     async def aresolve(self, interface: type[T], name: str | None = None) -> T: ...

--- a/tests/test_call.py
+++ b/tests/test_call.py
@@ -1,0 +1,108 @@
+"""container.call() / acall(): invoke a function with injected dependencies."""
+
+import asyncio
+
+import pytest
+
+from injex import Container, ServiceNotRegisteredException
+
+
+class Repo:
+    pass
+
+
+class Service:
+    def __init__(self, repo: Repo):
+        self.repo = repo
+
+
+def _container() -> Container:
+    c = Container()
+    c.add_singleton(Repo)
+    c.add_transient(Service)
+    return c
+
+
+def test_call_injects_and_overrides():
+    c = _container()
+
+    def handle(email: str, service: Service) -> tuple[str, Service]:
+        return email, service
+
+    email, service = c.call(handle, email="a@b.c")
+    assert email == "a@b.c"
+    assert isinstance(service, Service)
+
+
+def test_call_injects_container():
+    c = _container()
+
+    def needs(container) -> bool:
+        return container is c
+
+    assert c.call(needs) is True
+
+
+def test_call_respects_defaults_and_optional():
+    c = _container()
+
+    def handle(service: Service, page: int = 1) -> int:
+        return page
+
+    assert c.call(handle) == 1
+    assert c.call(handle, page=5) == 5
+
+
+def test_call_missing_dependency_raises_clear_error():
+    c = Container()  # Repo not registered
+
+    def handle(service: Service) -> None: ...
+
+    with pytest.raises(ServiceNotRegisteredException) as exc:
+        c.call(handle)
+    message = str(exc.value)
+    assert "Service" in message
+    assert "handle.service" in message  # error names the function parameter
+
+
+def test_acall_awaits_async_dependency_and_coroutine():
+    async def make_repo() -> Repo:
+        await asyncio.sleep(0)
+        return Repo()
+
+    async def main():
+        c = Container()
+        c.add_singleton_factory(Repo, make_repo)
+        c.add_transient(Service)
+
+        async def handle(tag: str, service: Service) -> str:
+            return f"{tag}:{type(service.repo).__name__}"
+
+        return await c.acall(handle, tag="x")
+
+    assert asyncio.run(main()) == "x:Repo"
+
+
+def test_acall_finalizes_async_resources_after_call():
+    events = []
+
+    async def session():
+        events.append("open")
+        try:
+            yield object()
+        finally:
+            events.append("close")
+
+    async def run():
+        c = Container()
+        c.add_scoped_factory(object, session)
+
+        async def handle(s: object) -> str:
+            assert events == ["open"]  # resource open during the call
+            return "ok"
+
+        out = await c.acall(handle)
+        assert out == "ok"
+        assert events == ["open", "close"]  # finalized when acall returned
+
+    asyncio.run(run())


### PR DESCRIPTION
## Why
You could resolve classes but not invoke a *function* with a mix of injected services and per-call values. That's the primitive handlers/CLI commands/consumers actually need — and what people reach to other DI libs for.

```python
def register_user(email: str, use_case: RegisterUser) -> int:
    return use_case.execute(email)

container.call(register_user, email="ada@example.com")  # use_case injected
```

- Parameters in `overrides` are passed as-is; the rest are resolved (optional/default and the `container` param respected).
- Missing dependencies raise the same clear error, now naming the function parameter (`required by register_user.use_case`).
- `acall` awaits async dependencies, awaits the function if it's a coroutine, and finalizes async resources opened for the call.

Small, explicit, zero new deps. Reuses the existing plan + resolution machinery. New tests in `tests/test_call.py`; docs in the tutorial and API reference.

mypy strict + ruff clean; 135 passed / 3 skipped.