### PR TITLE
Sync resources with teardown (generator factories)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project uses semantic versioning.
 
 ### Added
 
+- Sync resources with teardown. A generator factory (`def f(...): ...; yield x;
+  cleanup()`) is finalized when its scope exits (scoped/transient) or on
+  `container.close()` (singleton); the container is now a context manager too.
+  This mirrors the existing async-generator resources for synchronous code.
 - `container.call(func, **overrides)` (and async `acall`) invoke a function with
   its annotated parameters injected from the container, while `overrides` supplies
   per-call values (a request, parsed args, a message). `acall` awaits async

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,11 @@ be owned by one request/task — create one per request rather than sharing a
 single scope across threads. The container itself is thread-safe to resolve from;
 singletons are built once even under concurrent first resolves.
 
+A generator factory is a resource: scoped/transient resources are finalized when
+their scope exits (`with container.create_scope() as scope:`); singleton resources
+when `container.close()` is called (the container is also a context manager).
+Async resources work the same way through `ascope()` / `await container.aclose()`.
+
 ## Async
 
 Async factories (`async def`) and async-generator resources are registered with

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -78,6 +78,28 @@ There is a factory variant for each lifetime: `add_singleton_factory`,
 `add_transient_factory`, `add_scoped_factory`. Async (`async def`) factories and
 async-generator resources go through the async API — see [Async](./async.md).
 
+### Resources with teardown
+
+A **generator** factory is a resource: it yields the value and runs the code
+after the `yield` as teardown. Scoped/transient resources are finalized when their
+scope exits; singleton resources when `container.close()` is called (the container
+is also a context manager).
+
+```python
+def db_session(settings: Settings):
+    session = connect(settings.database_url)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+container.add_scoped_factory(Session, db_session)
+
+with container.create_scope() as scope:
+    session = scope.resolve(Session)  # closed when the block exits
+```
+
 ## Existing instances
 
 If you already hold an object, register it directly. It is treated as a

--- a/injex/container.py
+++ b/injex/container.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import threading
 from collections.abc import Callable
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, contextmanager
 from typing import (
     Any,
     TypeVar,
@@ -48,17 +48,20 @@ class _NotFlat(Exception):
 
 
 class Scope:
-    __slots__ = ("container", "_scoped_instances")
+    __slots__ = ("container", "_scoped_instances", "_stack")
 
     def __init__(self, container: "Container"):
         self.container = container
         self._scoped_instances: dict[Any, Any] = {}
+        # Holds sync resources opened in this scope; finalized (LIFO) on exit.
+        self._stack = ExitStack()
 
     def __enter__(self) -> "Scope":
         return self
 
     def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
-        # Drop per-scope instances so they aren't held past the block.
+        # Finalize sync resources (LIFO), then drop per-scope instances.
+        self._stack.close()
         self._scoped_instances.clear()
 
     @overload
@@ -140,6 +143,8 @@ class Container:
         "_async_creators",
         "_singleton_lock",
         "_async_inflight",
+        "_sync_stack",
+        "_sync_resource_keys",
     )
 
     def __init__(self) -> None:
@@ -181,6 +186,17 @@ class Container:
         # concurrent coroutines awaiting the same uncached singleton share one
         # build instead of each constructing their own.
         self._async_inflight: dict[Any, asyncio.Future[Any]] = {}
+        # Lazily created ExitStack holding singleton sync resources; finalized by
+        # container.close() at shutdown, with their instance_keys tracked so close()
+        # can evict them (mirrors the async stack / aclose()).
+        self._sync_stack: ExitStack | None = None
+        self._sync_resource_keys: set[Any] = set()
+
+    def __enter__(self) -> "Container":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.close()
 
     @property
     def _resolving(self) -> set[Any]:
@@ -244,6 +260,7 @@ class Container:
             kind=RegistrationType.FACTORY, factory=factory, lifestyle=lifestyle
         )
         registration.is_resource = inspect.isasyncgenfunction(factory)
+        registration.is_sync_resource = inspect.isgeneratorfunction(factory)
         registration.is_async = inspect.iscoroutinefunction(factory)
         self._registrations.setdefault(key, []).append(registration)
         self._invalidate_fast_creators()
@@ -303,6 +320,7 @@ class Container:
                 lifestyle=lifestyle,
             )
             registration.is_resource = inspect.isasyncgenfunction(factory)
+            registration.is_sync_resource = inspect.isgeneratorfunction(factory)
             registration.is_async = inspect.iscoroutinefunction(factory)
         else:
             if implementation is None:
@@ -338,9 +356,25 @@ class Container:
                 creator = self._prime_noscope_creator(interface)
             if creator is not None:
                 return creator(None)
+            self._guard_top_sync_resource(interface, None)
             scope = Scope(self)
             return self._resolve_one(interface, scope, None)
         return self._resolve_slow(interface, name)
+
+    def _guard_top_sync_resource(self, interface: type | str, name: str | None) -> None:
+        registrations = self._registrations.get((interface, name))
+        if registrations:
+            registration = registrations[0]
+            if registration.is_sync_resource and registration.lifestyle in (
+                LifeStyle.TRANSIENT,
+                LifeStyle.SCOPED,
+            ):
+                raise ValueError(
+                    f"{_describe_service(interface)} is a {registration.lifestyle} "
+                    "resource; resolve() would finalize it immediately. Resolve it "
+                    "inside 'with container.create_scope() as scope: "
+                    "scope.resolve(...)'."
+                )
 
     def _prime_noscope_creator(
         self, interface: type | str
@@ -373,6 +407,7 @@ class Container:
             fast_creator = registration.fast_creator
             if fast_creator is not None and not registration.fast_creator_needs_scope:
                 return fast_creator(None)
+        self._guard_top_sync_resource(interface, name)
         scope = self.create_scope()
         return self._resolve_one(interface, scope, name)
 
@@ -1067,6 +1102,8 @@ class Container:
                 return existing
             instance = self._create_instance_from_registration(registration, scope)
             self._singletons[instance_key] = instance
+            if registration.is_sync_resource:
+                self._sync_resource_keys.add(instance_key)
             return instance
 
     def _get_instance_from_registration(
@@ -1220,7 +1257,30 @@ class Container:
             self._resolve_dependency_plan(dependency_plan, scope, factory)
             for dependency_plan in plan.dependencies
         ]
+        if registration.is_sync_resource:
+            # Generator factory used as a resource: enter its context on the
+            # singleton's container stack (closed by close()) or the scope's stack
+            # (closed when the scope exits), so teardown runs after the yield.
+            cm = contextmanager(factory)(*args)
+            if registration.lifestyle == LifeStyle.SINGLETON:
+                return self._get_sync_stack().enter_context(cm)
+            return scope._stack.enter_context(cm)
         return factory(*args)
+
+    def _get_sync_stack(self) -> ExitStack:
+        if self._sync_stack is None:
+            self._sync_stack = ExitStack()
+        return self._sync_stack
+
+    def close(self) -> None:
+        """Finalize singleton sync resources. Call once at application shutdown
+        (or use the container as a context manager)."""
+        if self._sync_stack is not None:
+            stack, self._sync_stack = self._sync_stack, None
+            for instance_key in self._sync_resource_keys:
+                self._singletons.pop(instance_key, None)
+            self._sync_resource_keys.clear()
+            stack.close()
 
     # ------------------------------------------------------------------ async
 

--- a/injex/registry.py
+++ b/injex/registry.py
@@ -31,6 +31,7 @@ class Registration:
         "fast_creator_needs_scope",
         "is_async",
         "is_resource",
+        "is_sync_resource",
     )
 
     def __init__(
@@ -55,6 +56,10 @@ class Registration:
         # Both are resolved only through the async path; sync resolve rejects them.
         self.is_async = False
         self.is_resource = False
+        # A sync generator factory (`def f(...): ...; yield x; cleanup()`) used as
+        # a resource: finalized when its scope exits, or on container.close() for
+        # singletons. Resolved on the normal sync path.
+        self.is_sync_resource = False
 
 
 class OverrideContext:

--- a/tests/test_sync_resources.py
+++ b/tests/test_sync_resources.py
@@ -1,0 +1,141 @@
+"""Sync resources: generator factories with teardown around a scope / container."""
+
+import pytest
+
+from injex import Container
+
+
+class Settings:
+    pass
+
+
+def test_scoped_resource_finalized_on_scope_exit():
+    events = []
+
+    def session():
+        events.append("open")
+        try:
+            yield "SESSION"
+        finally:
+            events.append("close")
+
+    c = Container()
+    c.add_scoped_factory(str, session)
+
+    with c.create_scope() as scope:
+        a = scope.resolve(str)
+        b = scope.resolve(str)
+        assert a == b == "SESSION"  # one resource per scope
+        assert events == ["open"]
+    assert events == ["open", "close"]  # finalized on scope exit
+
+
+def test_transient_resource_finalized_on_scope_exit():
+    events = []
+
+    def handle():
+        events.append("open")
+        try:
+            yield object()
+        finally:
+            events.append("close")
+
+    c = Container()
+    c.add_transient_factory(object, handle)
+
+    with c.create_scope() as scope:
+        a = scope.resolve(object)
+        b = scope.resolve(object)
+        assert a is not b  # fresh per resolve
+        assert events == ["open", "open"]
+    assert events == ["open", "open", "close", "close"]  # both closed, LIFO
+
+
+def test_singleton_resource_finalized_on_close():
+    events = []
+
+    def pool():
+        events.append("open")
+        try:
+            yield "POOL"
+        finally:
+            events.append("close")
+
+    c = Container()
+    c.add_singleton_factory(str, pool)
+    assert c.resolve(str) == "POOL"
+    assert c.resolve(str) == "POOL"
+    assert events == ["open"]  # built once, survives between resolves
+    c.close()
+    assert events == ["open", "close"]
+
+
+def test_container_context_manager_closes_singleton_resources():
+    events = []
+
+    def res():
+        events.append("open")
+        try:
+            yield 1
+        finally:
+            events.append("close")
+
+    with Container() as c:
+        c.add_singleton_factory(int, res)
+        c.resolve(int)
+    assert events == ["open", "close"]
+
+
+def test_singleton_resource_reopens_after_close():
+    events = []
+
+    def res():
+        events.append("open")
+        try:
+            yield object()
+        finally:
+            events.append("close")
+
+    c = Container()
+    c.add_singleton_factory(object, res)
+    a = c.resolve(object)
+    c.close()
+    b = c.resolve(object)  # evicted on close -> rebuilt, not the closed instance
+    assert a is not b
+    assert events == ["open", "close", "open"]
+
+
+def test_resource_injected_into_service_within_scope():
+    events = []
+
+    def session(settings: Settings):
+        events.append("open")
+        try:
+            yield {"dsn": "x"}
+        finally:
+            events.append("close")
+
+    class Repo:
+        def __init__(self, session: dict):
+            self.session = session
+
+    c = Container()
+    c.add_instance(Settings, Settings())
+    c.add_scoped_factory(dict, session)
+    c.add_transient(Repo)
+
+    with c.create_scope() as scope:
+        repo = scope.resolve(Repo)
+        assert repo.session == {"dsn": "x"}
+        assert events == ["open"]
+    assert events == ["open", "close"]
+
+
+def test_container_resolve_of_scoped_resource_is_guarded():
+    def session():
+        yield "x"
+
+    c = Container()
+    c.add_scoped_factory(str, session)
+    with pytest.raises(ValueError, match="create_scope"):
+        c.resolve(str)


### PR DESCRIPTION
Async-generator resources had lifecycle; sync code didn't. Now a plain generator factory is a resource too:

```python
def db_session(settings: Settings):
    session = connect(settings.database_url)
    try:
        yield session
    finally:
        session.close()

container.add_scoped_factory(Session, db_session)
with container.create_scope() as scope:
    session = scope.resolve(Session)  # closed when the block exits
```

- Scoped/transient resources finalize (LIFO) when their scope exits; singleton resources on `container.close()`. The container is now a context manager (`with Container() as c:`), and a closed singleton resource is evicted so a later resolve rebuilds it.
- `container.resolve()` on a top-level scoped/transient resource raises a clear error pointing at `create_scope()` (it would otherwise finalize immediately) — symmetric with the async `aresolve` guard.
- Previously a sync generator factory was silently returned as a generator object; now it's entered as a context manager.

Sync resolve fast path untouched. New tests in `tests/test_sync_resources.py`; docs in tutorial + API reference. mypy strict + ruff clean, 142 passed / 3 skipped.