### PR TITLE
Close the 'where it doesn't fit' framework-wiring item; reframe config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,19 @@ if the graph needs async work, so you never silently get an un-awaited object. S
 [async resolution](./docs/async.md) and the
 [FastAPI example](./examples/fastapi_async.py).
 
-## Where it doesn't fit (yet)
+## Scope and non-goals
 
-- **No provider/config DSL.** If you want a rich configuration-injection system,
-  `dependency-injector` is a better fit.
-- **No deep framework auto-wiring.** Injex owns the graph; FastAPI/Typer adapt it at
-  their edge — it won't inject into route signatures for you.
+Injex stays small on purpose. Its one deliberate non-goal:
+
+- **No config-provider DSL.** Configuration is just another dependency: register a
+  settings object with `add_instance`, or individual values as named registrations
+  (`add_instance(str, dsn, name="database_url")`, injected with
+  `Annotated[str, Named("database_url")]`). Loading and coercing config from
+  env/files is left to tools built for it (`pydantic-settings`).
+
+Framework wiring it *does* do: [`injex.ext.fastapi`](./docs/fastapi-depends.md)
+injects services into FastAPI routes, and `container.call(fn, ...)` injects into
+any function — Typer/Click commands, workers, message handlers.
 
 ## Performance
 

--- a/docs/di-frameworks.md
+++ b/docs/di-frameworks.md
@@ -6,20 +6,17 @@ decision, see the [comparison guide](./comparison.md).
 
 ## Where Injex loses
 
-Pick a larger framework when you need any of these — Injex deliberately doesn't do
-them:
+Pick a larger framework when you need this — Injex deliberately doesn't do it:
 
-- **Framework-native scopes for async resources.** Injex does open and close async
-  resources (connection pools, `async def ... yield`) via `ascope()` / `aclose()`
-  (see [async resolution](./async.md)). What the larger frameworks add on top is
-  deeper integration with framework-managed request/session scopes — Dishka in
-  particular wires its scopes directly into FastAPI/Litestar. With Injex you open
-  the scope yourself at the request boundary.
-- **A configuration/provider DSL.** If wiring config values through provider objects
-  is part of your architecture, `dependency-injector` is purpose-built for it.
-- **Deep framework auto-wiring.** Dishka/Wireup can plug directly into FastAPI or
-  task-framework scopes and inject into handler signatures. Injex stays at the
-  composition root and lets the framework adapt the graph at its edge.
+- **A configuration/provider DSL.** Loading config from env/files, coercing types,
+  and wiring values through provider objects is `dependency-injector`'s domain. In
+  Injex configuration is a normal dependency: register a settings object, or values
+  as named registrations and inject them with `Annotated[T, Named(...)]`.
+
+Things people often assume Injex *can't* do, but it can: it manages async (and
+sync) resource lifecycles via `ascope()` / `create_scope()`, injects into FastAPI
+routes through [`injex.ext.fastapi`](./fastapi-depends.md), and injects into any
+function (Typer/Click commands, workers) through `container.call()`.
 
 ## Dependency Injector
 

--- a/examples/config_injection.py
+++ b/examples/config_injection.py
@@ -1,0 +1,46 @@
+"""Configuration is just a dependency in Injex — no separate config DSL.
+
+Two ways to inject it: a whole settings object, or individual named values.
+"""
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from injex import Container, Named
+
+
+@dataclass
+class Settings:
+    database_url: str
+    smtp_url: str
+
+
+# 1. Inject the settings object.
+class Reporting:
+    def __init__(self, settings: Settings):
+        self.dsn = settings.database_url
+
+
+# 2. Inject an individual value by name.
+class Mailer:
+    def __init__(self, smtp: Annotated[str, Named("smtp_url")]):
+        self.smtp = smtp
+
+
+def main() -> None:
+    settings = Settings(database_url="postgres://db", smtp_url="smtp://mail")
+
+    container = Container()
+    container.add_instance(Settings, settings)
+    container.add_instance(str, settings.smtp_url, name="smtp_url")
+    container.add_transient(Reporting)
+    container.add_transient(Mailer)
+    container.assert_valid()
+
+    assert container.resolve(Reporting).dsn == "postgres://db"
+    assert container.resolve(Mailer).smtp == "smtp://mail"
+    print("config injected:", container.resolve(Mailer).smtp)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/docs/di-frameworks.html
+++ b/site/docs/di-frameworks.html
@@ -65,25 +65,21 @@
         </p>
 
         <h2>Where Injex loses</h2>
-        <p>Pick a larger framework when you need any of these — Injex deliberately
-          doesn't do them:</p>
+        <p>Pick a larger framework when you need this — Injex deliberately doesn't
+          do it:</p>
         <ul>
-          <li><strong>Framework-native scopes for async resources.</strong> Injex does
-            open and close async resources (connection pools,
-            <code>async def ... yield</code>) via <code>ascope()</code> /
-            <code>aclose()</code> — see <a href="./async.html">async resolution</a>.
-            What the larger frameworks add is deeper integration with framework-managed
-            request/session scopes; Dishka in particular wires its scopes directly into
-            FastAPI/Litestar. With Injex you open the scope yourself at the request
-            boundary.</li>
-          <li><strong>A configuration/provider DSL.</strong> If wiring config values
-            through provider objects is part of your architecture,
-            <code>dependency-injector</code> is purpose-built for it.</li>
-          <li><strong>Deep framework auto-wiring.</strong> Dishka and Wireup plug
-            directly into FastAPI or task-framework scopes and inject into handler
-            signatures. Injex stays at the composition root and lets the framework
-            adapt the graph at its edge.</li>
+          <li><strong>A configuration/provider DSL.</strong> Loading config from
+            env/files, coercing types, and wiring values through provider objects is
+            <code>dependency-injector</code>'s domain. In Injex configuration is a
+            normal dependency: register a settings object, or values as named
+            registrations and inject them with <code>Annotated[T, Named(...)]</code>.</li>
         </ul>
+        <p>Things people assume Injex can't do, but it can: it manages async and sync
+          resource lifecycles via <code>ascope()</code> / <code>create_scope()</code>,
+          injects into FastAPI routes through
+          <a href="./fastapi-depends.html"><code>injex.ext.fastapi</code></a>, and
+          injects into any function (Typer/Click commands, workers) through
+          <code>container.call()</code>.</p>
         <p>For the general manual-vs-framework-vs-Injex decision, see the
           <a href="./comparison.html">comparison guide</a>.</p>
 


### PR DESCRIPTION
Now that `injex.ext.fastapi.Provide` injects into FastAPI routes and `container.call()` injects into any function, the README/docs claim that Injex "won't inject into route signatures" is stale — removed it and pointed at what's actually supported.

The one real non-goal stays, reframed honestly: Injex has no config-provider DSL, but configuration *is* injectable — a settings object via `add_instance`, or individual values as named registrations (`Annotated[T, Named(...)]`). Loading/coercing config from env/files is left to `pydantic-settings`. Adds `examples/config_injection.py`.

Docs-only + example; no code change.