### PR TITLE
Auto-registration: @injectable + container.scan()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project uses semantic versioning.
 
 ### Added
 
+- Auto-registration: mark classes with `@injectable` (optionally
+  `lifestyle=`, `name=`, `provides=`) and register them in one call with
+  `container.scan(module)` or `container.scan([Class, ...])`. Scanning a module
+  registers only classes defined there, and nothing is registered as an import
+  side effect — registration stays explicit.
 - FastAPI integration (`injex.ext.fastapi`, optional extra `injex[fastapi]`).
   `setup_injex(app, container)` opens one Injex scope per request and finalizes
   its resources when the request ends (and closes singleton resources on

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -100,6 +100,37 @@ with container.create_scope() as scope:
     session = scope.resolve(Session)  # closed when the block exits
 ```
 
+## Auto-registration
+
+For larger apps, marking classes and registering them in one call beats a long
+list of `add_*` lines. Decorate with `@injectable` and `scan` a module:
+
+```python
+from injex import Container, injectable
+
+
+@injectable                          # transient by default
+class UserRepository: ...
+
+
+@injectable(lifestyle="singleton")
+class ApiClient: ...
+
+
+@injectable(provides=Notifier, name="email")
+class EmailNotifier(Notifier): ...
+
+
+import myapp.services
+container = Container()
+container.scan(myapp.services)        # registers the marked classes above
+```
+
+`scan` registers only classes *defined* in the module (not imported ones), and
+nothing happens until you call it — `@injectable` is just a marker, so importing
+a module never registers anything behind your back. You can also pass an explicit
+list: `container.scan([UserRepository, ApiClient])`.
+
 ## Existing instances
 
 If you already hold an object, register it directly. It is treated as a

--- a/injex/__init__.py
+++ b/injex/__init__.py
@@ -55,6 +55,9 @@ from .registry import (
 from .registry import (
     RegistrationType as RegistrationType,
 )
+from .registry import (
+    injectable as injectable,
+)
 
 __all__ = [
     "AsyncResolutionRequiredException",
@@ -72,4 +75,5 @@ __all__ = [
     "ServiceNotRegisteredException",
     "ValidationError",
     "inject",
+    "injectable",
 ]

--- a/injex/container.py
+++ b/injex/container.py
@@ -36,7 +36,13 @@ from .planning import (
     _normalize_dependency_type,
     _ServicePlan,
 )
-from .registry import LifeStyle, OverrideContext, Registration, RegistrationType
+from .registry import (
+    _SCAN_ATTR,
+    LifeStyle,
+    OverrideContext,
+    Registration,
+    RegistrationType,
+)
 
 _MISSING = object()
 
@@ -424,6 +430,35 @@ class Container:
         """Open a sync scope. Scoped services are cached per-scope; for async
         resources use ``async with container.ascope()`` instead."""
         return Scope(self)
+
+    def scan(self, *sources: Any) -> None:
+        """Register every ``@injectable`` class found in the given modules.
+
+        Pass modules (only classes *defined* there are registered, not imported
+        ones) or any iterable of classes. Registration is explicit — it happens
+        here, not as an import side effect.
+        """
+        for source in sources:
+            if inspect.ismodule(source):
+                candidates = [
+                    obj
+                    for obj in vars(source).values()
+                    if isinstance(obj, type)
+                    and getattr(obj, "__module__", None) == source.__name__
+                ]
+            else:
+                candidates = list(source)
+            for obj in candidates:
+                info = obj.__dict__.get(_SCAN_ATTR)
+                if info is None:
+                    continue
+                interface = info["provides"] or obj
+                self.register(
+                    interface,
+                    obj,
+                    lifestyle=info["lifestyle"],
+                    name=info["name"],
+                )
 
     def call(self, func: Callable[..., T], /, **overrides: Any) -> T:
         """Call ``func``, injecting its annotated parameters from the container.

--- a/injex/registry.py
+++ b/injex/registry.py
@@ -18,6 +18,35 @@ class RegistrationType:
     INSTANCE = "instance"
 
 
+_SCAN_ATTR = "__injex_register__"
+
+
+def injectable(
+    cls: type | None = None,
+    *,
+    lifestyle: str = LifeStyle.TRANSIENT,
+    name: str | None = None,
+    provides: type | None = None,
+) -> Any:
+    """Mark a class for `container.scan()` to register automatically.
+
+    Usable bare (`@injectable`) or with options
+    (`@injectable(lifestyle="singleton", provides=Repository)`). Registration
+    still only happens when you call `container.scan(module)` — nothing is
+    registered as a side effect of import.
+    """
+
+    def wrap(target: type) -> type:
+        setattr(
+            target,
+            _SCAN_ATTR,
+            {"lifestyle": lifestyle, "name": name, "provides": provides},
+        )
+        return target
+
+    return wrap if cls is None else wrap(cls)
+
+
 class Registration:
     __slots__ = (
         "factory",

--- a/tests/_scan_app.py
+++ b/tests/_scan_app.py
@@ -1,0 +1,35 @@
+"""Support module for test_scan: classes defined here for container.scan()."""
+
+from injex import injectable
+
+# An imported, already-marked class — scanning this module must NOT register it,
+# because it isn't defined here.
+from tests._scan_other import Foreign as Foreign
+
+
+class Database:
+    pass
+
+
+@injectable
+class Repository:
+    def __init__(self, db: Database):
+        self.db = db
+
+
+@injectable(lifestyle="singleton")
+class Cache:
+    pass
+
+
+class Port:
+    pass
+
+
+@injectable(provides=Port, name="primary")
+class Adapter(Port):
+    pass
+
+
+class Unmarked:  # no decorator -> never registered
+    pass

--- a/tests/_scan_other.py
+++ b/tests/_scan_other.py
@@ -1,0 +1,8 @@
+"""Support module: a marked class that lives elsewhere."""
+
+from injex import injectable
+
+
+@injectable
+class Foreign:
+    pass

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,43 @@
+"""container.scan(): auto-register @injectable classes."""
+
+from injex import Container
+from tests import _scan_app
+from tests._scan_app import Adapter, Cache, Database, Port, Repository, Unmarked
+from tests._scan_other import Foreign
+
+
+def test_scan_module_registers_marked_classes_with_lifestyles():
+    c = Container()
+    c.add_singleton(Database)  # a plain dependency the marked Repository needs
+    c.scan(_scan_app)
+
+    assert isinstance(c.resolve(Repository), Repository)
+    assert c.resolve(Repository) is not c.resolve(Repository)  # transient default
+    assert c.resolve(Cache) is c.resolve(Cache)  # singleton
+
+
+def test_scan_respects_provides_and_name():
+    c = Container()
+    c.scan(_scan_app)
+    assert isinstance(c.resolve(Port, name="primary"), Adapter)
+
+
+def test_scan_skips_unmarked_and_imported_classes():
+    c = Container()
+    c.scan(_scan_app)
+    # Unmarked has no decorator; Foreign is imported, not defined in _scan_app.
+    assert c._registrations.get((Unmarked, None)) is None
+    assert c._registrations.get((Foreign, None)) is None
+
+
+def test_scan_accepts_an_iterable_of_classes():
+    c = Container()
+    c.add_singleton(Database)
+    c.scan([Repository, Cache])
+    assert isinstance(c.resolve(Repository), Repository)
+
+
+def test_scan_does_not_register_on_import():
+    # Importing the module must not register anything by itself.
+    fresh = Container()
+    assert fresh._registrations == {}


### PR DESCRIPTION
Cuts the long list of `add_*` lines in larger apps without giving up explicit control.

```python
from injex import injectable

@injectable
class UserRepository: ...

@injectable(lifestyle="singleton")
class ApiClient: ...

@injectable(provides=Notifier, name="email")
class EmailNotifier(Notifier): ...

container.scan(myapp.services)   # registers the marked classes
```

- `@injectable` is just a marker (stores lifestyle/name/provides on the class); **nothing is registered on import** — only when you call `scan`.
- `scan(module)` registers only classes *defined* in that module (imported-but-marked classes are skipped); also accepts an explicit `[Class, ...]` iterable.
- Inherited markers don't leak (checks `__dict__` directly).

New tests in `tests/test_scan.py`; docs in the tutorial. mypy strict + ruff clean, 148 passed / 5 skipped.