### PR TITLE
CLI injection: injex.ext.cli (Inject + wire)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project uses semantic versioning.
 
 ### Added
 
+- CLI injection (`injex.ext.cli`). Mark a command's service parameters with
+  `Inject()` and wrap it with `wire(container)`; the services are injected while
+  the CLI framework (Typer, Click, argparse, …) only sees the remaining
+  parameters. Pure-stdlib and framework-agnostic.
 - Auto-registration: mark classes with `@injectable` (optionally
   `lifestyle=`, `name=`, `provides=`) and register them in one call with
   `container.scan(module)` or `container.scan([Class, ...])`. Scanning a module

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -159,6 +159,19 @@ container.call(register_user, email="ada@example.com")  # use_case is injected
 function if it's a coroutine, and finalizes any async resources opened for the
 call when it returns.
 
+For CLI commands, [`injex.ext.cli`](./recipes.md) wraps this up: mark the service
+parameters with `Inject()` and decorate the command with `wire(container)`, and
+Typer/Click only see the real CLI arguments.
+
+```python
+from injex.ext.cli import Inject, wire
+
+@app.command()
+@wire(container)
+def greet(name: str, greeter: Greeter = Inject()):
+    print(greeter.greet(name))
+```
+
 ## Scopes
 
 A scope is a boundary that scoped services live inside of — typically one web

--- a/examples/cli_injection.py
+++ b/examples/cli_injection.py
@@ -1,0 +1,29 @@
+"""CLI command with injected services via injex.ext.cli.
+
+Run: pip install click; python -m examples.cli_injection greet ada
+"""
+
+import click
+
+from injex import Container
+from injex.ext.cli import Inject, wire
+
+
+class Greeter:
+    def greet(self, name: str) -> str:
+        return f"hello, {name}"
+
+
+container = Container()
+container.add_singleton(Greeter)
+
+
+@click.command()
+@click.argument("name")
+@wire(container)
+def greet(name: str, greeter: Greeter = Inject()) -> None:
+    click.echo(greeter.greet(name))
+
+
+if __name__ == "__main__":
+    greet()

--- a/injex/ext/cli.py
+++ b/injex/ext/cli.py
@@ -1,0 +1,67 @@
+"""Inject services into CLI command functions (Typer, Click, argparse, …).
+
+Mark the injected parameters with ``Inject()`` and wrap the command with
+``wire(container)``. The CLI framework only sees the remaining parameters, so it
+builds options/arguments for those while the services come from the container.
+
+    import typer
+    from injex.ext.cli import Inject, wire
+
+    app = typer.Typer()
+
+    @app.command()
+    @wire(container)
+    def greet(name: str, greeter: Greeter = Inject()):
+        print(greeter.greet(name))
+
+Framework-agnostic: it only rewrites the wrapped function's signature, which is
+what Typer, Click, and the standard library all read.
+"""
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from injex import Container
+
+T = TypeVar("T")
+
+
+class _InjectMarker:
+    __slots__ = ()
+
+
+_INJECT = _InjectMarker()
+
+
+def Inject() -> Any:
+    """Default marker for a parameter that should be injected, not asked of the
+    CLI. See the module docstring."""
+    return _INJECT
+
+
+def wire(container: "Container") -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Decorator that injects the ``Inject()``-marked parameters of a command
+    from ``container`` and hides them from the CLI framework's view."""
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        signature = inspect.signature(func)
+        visible = [
+            param
+            for param in signature.parameters.values()
+            if param.default is not _INJECT
+        ]
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            provided = dict(kwargs)
+            for param, value in zip(visible, args, strict=False):
+                provided[param.name] = value
+            return container.call(func, **provided)
+
+        wrapper.__signature__ = signature.replace(parameters=visible)  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,11 @@ fastapi = ["fastapi>=0.100"]
 
 [tool.uv]
 # fastapi/httpx are intentionally NOT here: the type-check and FastAPI jobs add
-# them per-run with `uv run --with`, so the main test matrix (incl. Python 3.14,
-# where pydantic-core has no wheel yet) never builds pydantic. The integration
-# tests skip when FastAPI is absent.
+# them per-job (they pull pydantic-core, which has no wheel for Python 3.14 yet).
+# The FastAPI tests skip when FastAPI is absent. click is pure-Python and safe on
+# every supported version, so it stays a normal dev dependency.
 dev-dependencies = [
+    "click>=8.0",
     "mypy>=1.12.1",
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",

--- a/tests/test_ext_cli.py
+++ b/tests/test_ext_cli.py
@@ -1,0 +1,54 @@
+"""CLI injection: Inject() + wire(), exercised with a real Click command."""
+
+import inspect
+
+import click
+from click.testing import CliRunner
+
+from injex import Container
+from injex.ext.cli import Inject, wire
+
+
+class Greeter:
+    def greet(self, name: str) -> str:
+        return f"hello {name}"
+
+
+def test_wire_hides_injected_params_from_signature():
+    c = Container()
+    c.add_singleton(Greeter)
+
+    @wire(c)
+    def cmd(name: str, greeter: Greeter = Inject()) -> str:
+        return greeter.greet(name)
+
+    assert list(inspect.signature(cmd).parameters) == ["name"]  # greeter hidden
+    assert cmd("ada") == "hello ada"  # greeter injected
+
+
+def test_wire_with_real_click_command():
+    container = Container()
+    container.add_singleton(Greeter)
+
+    @click.command()
+    @click.argument("name")
+    @wire(container)
+    def greet(name: str, greeter: Greeter = Inject()) -> None:
+        click.echo(greeter.greet(name))
+
+    result = CliRunner().invoke(greet, ["ada"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "hello ada"
+
+
+def test_wire_injects_container_and_respects_overrides():
+    container = Container()
+    container.add_singleton(Greeter)
+
+    @wire(container)
+    def cmd(name: str, greeter: Greeter = Inject(), suffix: str = "!") -> str:
+        return greeter.greet(name) + suffix
+
+    # suffix stays a normal (visible) parameter; greeter is injected.
+    assert list(inspect.signature(cmd).parameters) == ["name", "suffix"]
+    assert cmd("bob", suffix="?") == "hello bob?"

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +272,7 @@ fastapi = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "click" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -273,6 +286,7 @@ requires-dist = [{ name = "fastapi", marker = "extra == 'fastapi'", specifier = 
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "click", specifier = ">=8.0" },
     { name = "mypy", specifier = ">=1.12.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },


### PR DESCRIPTION
Injects services into CLI command functions without making the CLI framework aware of them.

```python
from injex.ext.cli import Inject, wire

@app.command()
@wire(container)
def greet(name: str, greeter: Greeter = Inject()):
    print(greeter.greet(name))
```

`wire(container)` rewrites the wrapped function's signature to drop the `Inject()`-marked parameters (what Typer/Click/argparse read), and resolves them from the container at call time via `container.call`. Framework-agnostic and pure-stdlib — no Typer/Click dependency in the library.

Tested for real against a Click command (`CliRunner`); `click` added as a dev dependency (pure-Python, installs on every supported version incl. 3.14). New `tests/test_ext_cli.py`, `examples/cli_injection.py`, docs. mypy strict + ruff clean, 152 passed / 5 skipped.