### PR TITLE
Docs/site refresh: surface the full feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,55 @@ with container.override(EmailSender, instance=fake_sender):
 See the [tutorial](./docs/tutorial.md) for factories, named registrations,
 `resolve_all()`, optional dependencies, and property injection.
 
+## Wire functions, not just classes
+
+`call()` invokes any function with its annotated parameters injected, while you
+pass the rest — a request, parsed args, a message. It's the building block for
+handlers and commands without turning them into classes:
+
+```python
+def register_user(email: str, use_case: RegisterUser) -> int:
+    return use_case.execute(email)
+
+container.call(register_user, email="ada@example.com")  # use_case is injected
+```
+
+**FastAPI** — `injex.ext.fastapi` opens a scope per request and injects into routes
+(`pip install injex[fastapi]`):
+
+```python
+from injex.ext.fastapi import Provide, setup_injex
+
+setup_injex(app, container)
+
+@app.post("/users")
+async def create(use_case: RegisterUser = Provide(RegisterUser)):
+    return use_case.execute(...)
+```
+
+**Typer / Click** — `injex.ext.cli` injects services; the CLI framework only sees
+the real arguments:
+
+```python
+from injex.ext.cli import Inject, wire
+
+@app.command()
+@wire(container)
+def register(email: str, use_case: RegisterUser = Inject()):
+    use_case.execute(email)
+```
+
+**Larger apps** — mark classes with `@injectable` and register them in one call:
+
+```python
+from injex import injectable
+
+@injectable(lifestyle="singleton")
+class ApiClient: ...
+
+container.scan(myapp.services)  # registers every @injectable defined there
+```
+
 ## When to use it
 
 - A service layer reused by an API, CLI, worker, and tests, where copy-pasted
@@ -200,15 +249,17 @@ For a deeper, fair comparison see [Injex vs other DI options](./docs/comparison.
 
 | Method | Use when |
 | --- | --- |
-| `add_singleton(T, Impl)` | One instance reused for the app lifetime. |
-| `add_transient(T, Impl)` | A new instance on every resolve. |
-| `add_scoped(T, Impl)` | One instance reused inside one scope. |
-| `add_*_factory(T, factory)` | Construction needs custom code. |
+| `add_singleton/transient/scoped(T, Impl)` | Register a class for the chosen lifetime. |
+| `add_*_factory(T, factory)` | Construction needs custom code; a generator factory becomes a resource with teardown. |
 | `add_instance(T, instance)` | You already have the object. |
+| `scan(module)` | Register every `@injectable` class in a module. |
 | `resolve(T)` / `resolve_all(T)` | Resolve one, or all unnamed implementations. |
-| `create_scope()` | Start a request, job, or message lifetime. |
+| `call(fn, **overrides)` | Invoke a function with its dependencies injected. |
+| `create_scope()` | Start a request/job lifetime (`with` finalizes scoped resources). |
 | `override(T, ...)` | Temporarily replace a dependency in tests. |
 | `validate()` / `assert_valid()` | Check wiring before startup. |
+| `aresolve(T)` / `ascope()` / `acall(fn)` / `aclose()` | Async equivalents (await factories, async resources). |
+| `close()` | Finalize singleton resources at shutdown. |
 
 ## Documentation
 
@@ -222,8 +273,10 @@ For a deeper, fair comparison see [Injex vs other DI options](./docs/comparison.
   [Performance](./docs/performance.md)
 - Examples:
   [clean architecture](./examples/clean_architecture.py),
-  [FastAPI lifespan](./examples/fastapi_lifespan.py),
-  [CLI](./examples/cli_app.py),
+  [FastAPI integration](./examples/fastapi_ext.py),
+  [CLI injection](./examples/cli_injection.py),
+  [config injection](./examples/config_injection.py),
+  [async FastAPI](./examples/fastapi_async.py),
   [testing](./examples/testing.py),
   [scopes](./examples/scoped.py)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,23 @@
 Start here when you want to wire a small Python application without pulling in a
 framework-sized dependency injection container.
 
+## What Injex does
+
+- **Constructor injection** from plain type hints, with singleton / transient /
+  scoped lifetimes, factories, named registrations, optional dependencies, and
+  property injection — see the [tutorial](./tutorial.md).
+- **Validation** of the whole graph before anything is constructed
+  ([validation](./validation.md)).
+- **Resources with teardown**, sync and async, finalized when their scope exits or
+  on `close()` / `aclose()` ([async](./async.md)).
+- **Function injection** — `call()` / `acall()` inject into any function
+  ([tutorial](./tutorial.md#calling-functions)).
+- **Auto-registration** — `@injectable` + `scan()`
+  ([tutorial](./tutorial.md#auto-registration)).
+- **Integrations** — [FastAPI](./fastapi-depends.md#optional-integration)
+  (`injex.ext.fastapi`) and Typer/Click (`injex.ext.cli`).
+- **Zero runtime dependencies**, typed (PEP 561), Python 3.10–3.14.
+
 ## Guides
 
 - [Tutorial](./tutorial.md): registrations, lifetimes, factories, overrides, and

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -56,7 +56,13 @@ Use scoped registrations for request-owned objects, such as database sessions,
 unit-of-work objects, request context, or per-request caches. Keep long-lived
 clients as singletons.
 
-See also: [`examples/fastapi_app.py`](../examples/fastapi_app.py).
+The boilerplate above (the scope dependency and the per-service wrapper) is what
+the optional `injex.ext.fastapi` integration writes for you — `setup_injex(app,
+container)` plus `use_case: RegisterUser = Provide(RegisterUser)`. See
+[Compared to FastAPI Depends](./fastapi-depends.md#optional-integration).
+
+See also: [`examples/fastapi_app.py`](../examples/fastapi_app.py) and
+[`examples/fastapi_ext.py`](../examples/fastapi_ext.py).
 
 ## Worker job scope
 
@@ -167,7 +173,21 @@ def main() -> None:
     container.resolve(SyncUsersCommand).run()
 ```
 
-See also: [`examples/cli_app.py`](../examples/cli_app.py).
+With Typer or Click, `injex.ext.cli` injects the command object so the framework
+only sees real CLI arguments:
+
+```python
+from injex.ext.cli import Inject, wire
+
+
+@app.command()
+@wire(container)
+def sync_users(command: SyncUsersCommand = Inject()) -> None:
+    command.run()
+```
+
+See also: [`examples/cli_app.py`](../examples/cli_app.py) and
+[`examples/cli_injection.py`](../examples/cli_injection.py).
 
 ## Test override boundary
 

--- a/site/index.html
+++ b/site/index.html
@@ -253,6 +253,45 @@ container.assert_valid()
 service = container.resolve(Service)</code></pre>
       </section>
 
+      <section id="features" class="cards section" aria-label="Capabilities">
+        <article>
+          <span class="card-icon">★</span>
+          <h3>Validate before startup</h3>
+          <p>Check the whole graph — missing deps, missing annotations, cycles —
+            without constructing anything.</p>
+        </article>
+        <article>
+          <span class="card-icon">★</span>
+          <h3>Lifetimes &amp; resources</h3>
+          <p>Singleton, transient, scoped — plus generator factories with teardown,
+            finalized when a scope exits or on <code>close()</code>.</p>
+        </article>
+        <article>
+          <span class="card-icon">★</span>
+          <h3>Async, first-class</h3>
+          <p><code>aresolve()</code> / <code>ascope()</code> await async factories
+            and async-resource lifecycles, on par with sync speed.</p>
+        </article>
+        <article>
+          <span class="card-icon">★</span>
+          <h3>Inject into functions</h3>
+          <p><code>call()</code> wires any handler or command; pass the request or
+            args, the services are injected.</p>
+        </article>
+        <article>
+          <span class="card-icon">★</span>
+          <h3>FastAPI &amp; CLI</h3>
+          <p><code>injex.ext.fastapi</code> injects into routes with a per-request
+            scope; <code>injex.ext.cli</code> wires Typer/Click commands.</p>
+        </article>
+        <article>
+          <span class="card-icon">★</span>
+          <h3>Auto-registration</h3>
+          <p>Mark classes with <code>@injectable</code> and register a whole module
+            with <code>container.scan()</code> — still explicit.</p>
+        </article>
+      </section>
+
       <section class="section comparison">
         <p class="eyebrow">Positioning</p>
         <h2>Small by design, useful by contract.</h2>

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -31,12 +31,22 @@ use_case = container.resolve(RegisterUser)
 - Constructor injection from Python type hints.
 - Singleton, transient, and scoped lifetimes.
 - Factories and prebuilt instances.
-- Named registrations.
-- Optional dependencies.
+- Named registrations, injectable into constructors via `Annotated[T, Named(...)]`.
+- Optional dependencies and property injection.
 - Temporary test overrides.
 - Graph validation before startup.
 - Cycle detection.
 - Cached dependency plans and fast repeated resolves.
+- Resources with teardown: sync (`def f(): ...; yield x; cleanup()`) and async
+  (`async def f(): ...; yield x; await cleanup()`) generator factories, finalized
+  when their scope exits or on `container.close()` / `await container.aclose()`.
+- Async resolution: `aresolve()`, `ascope()`, `acall()`, `aclose()`.
+- Function injection: `container.call(fn, **overrides)` (and async `acall`) inject
+  a function's annotated parameters while the caller passes the rest.
+- Auto-registration: mark classes with `@injectable` and register a module with
+  `container.scan(module)`; nothing registers as an import side effect.
+- Integrations: `injex.ext.fastapi` (`setup_injex` + `Provide`, one scope per
+  request) and `injex.ext.cli` (`Inject` + `wire` for Typer/Click commands).
 
 ## Target use cases
 

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -13,10 +13,18 @@ Key facts:
 - Package: `injex`
 - Runtime dependencies: none
 - License: MIT
-- Core API: `Container`, `Scope`, `inject`
+- Core API: `Container`, `Scope`, `inject`, `injectable`, `Named`
 - Lifetimes: singleton, transient, scoped
 - Features: typed constructor injection, factories, instances, named
-  registrations, optional dependencies, test overrides, graph validation
+  registrations (`Annotated[T, Named(...)]`), optional dependencies, property
+  injection, test overrides, graph validation
+- Resources: generator factories (sync and async) with teardown finalized on
+  scope exit or `close()` / `aclose()`
+- Async: `aresolve()`, `ascope()`, `acall()`, `aclose()`
+- Function injection: `container.call(fn, **overrides)` / `acall`
+- Auto-registration: `@injectable` + `container.scan(module)`
+- Integrations: `injex.ext.fastapi` (per-request scope + `Provide`),
+  `injex.ext.cli` (`Inject` + `wire` for Typer/Click)
 - Performance snapshot: `0.333 µs/op` median resolve time on the project small
   service-graph benchmark
 


### PR DESCRIPTION
Brings the public-facing surfaces up to date with everything shipped since 1.5 — the capabilities existed but weren't discoverable.

**README**
- New "Wire functions, not just classes" section: `call()`, FastAPI `Provide`, Typer/Click `wire`/`Inject`, and `@injectable` + `scan`.
- Expanded the API-at-a-glance table (call/acall, scan, ascope/aresolve/aclose, close, resources).
- Refreshed the examples list (FastAPI integration, CLI injection, config injection).

**docs**
- `docs/index.md`: a "What Injex does" overview linking each capability.
- `recipes.md`: FastAPI and CLI recipes now point at `injex.ext.fastapi` / `injex.ext.cli`.

**site**
- `index.html`: a Capabilities section (validation, lifetimes & resources, async, function injection, FastAPI/CLI, auto-registration).
- `llms.txt` / `llms-full.txt`: list the new features for AI/SEO discovery.

Docs/site only — no code change. Links and anchors verified; ruff/format clean, 152 passed / 5 skipped.