### PR TITLE
Audit fixes: error-message + typing polish

### DIFF
--- a/injex/container.py
+++ b/injex/container.py
@@ -46,6 +46,16 @@ from .registry import (
 
 _MISSING = object()
 
+_VALID_LIFESTYLES = frozenset(
+    {LifeStyle.TRANSIENT, LifeStyle.SINGLETON, LifeStyle.SCOPED}
+)
+
+
+def _ensure_valid_lifestyle(lifestyle: str) -> None:
+    if lifestyle not in _VALID_LIFESTYLES:
+        raise InvalidLifestyleException(lifestyle)
+
+
 T = TypeVar("T")
 
 
@@ -226,12 +236,7 @@ class Container:
     ) -> None:
         """Register a class. ``implementation`` defaults to ``interface``.
         Dependencies are read from the constructor's type hints."""
-        if lifestyle not in (
-            LifeStyle.TRANSIENT,
-            LifeStyle.SINGLETON,
-            LifeStyle.SCOPED,
-        ):
-            raise InvalidLifestyleException(lifestyle)
+        _ensure_valid_lifestyle(lifestyle)
         if implementation is None:
             implementation = interface
         key = (interface, name)
@@ -255,12 +260,7 @@ class Container:
         (``async def ... yield``) are supported via aresolve()/ascope()."""
         if not callable(factory):
             raise ValueError("Factory must be callable")
-        if lifestyle not in (
-            LifeStyle.TRANSIENT,
-            LifeStyle.SINGLETON,
-            LifeStyle.SCOPED,
-        ):
-            raise InvalidLifestyleException(lifestyle)
+        _ensure_valid_lifestyle(lifestyle)
         key = (interface, name)
         registration = Registration(
             kind=RegistrationType.FACTORY, factory=factory, lifestyle=lifestyle
@@ -304,12 +304,7 @@ class Container:
                 "Provide only one override target: "
                 "implementation, factory, or instance."
             )
-        if lifestyle not in (
-            LifeStyle.TRANSIENT,
-            LifeStyle.SINGLETON,
-            LifeStyle.SCOPED,
-        ):
-            raise InvalidLifestyleException(lifestyle)
+        _ensure_valid_lifestyle(lifestyle)
 
         if instance is not None:
             registration = Registration(
@@ -1393,9 +1388,9 @@ class Container:
                 LifeStyle.SCOPED,
             ):
                 raise ValueError(
-                    f"{interface} is a {registration.lifestyle} async resource; "
-                    "aresolve() would finalize it immediately. Resolve it inside "
-                    "'async with container.ascope() as scope: "
+                    f"{_describe_service(interface)} is a {registration.lifestyle} "
+                    "async resource; aresolve() would finalize it immediately. "
+                    "Resolve it inside 'async with container.ascope() as scope: "
                     "await scope.aresolve(...)'."
                 )
 

--- a/injex/errors.py
+++ b/injex/errors.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 
 class DIException(Exception):
@@ -16,15 +17,16 @@ class ServiceNotRegisteredException(DIException):
 
 
 class CyclicDependencyException(DIException):
-    def __init__(self, cls: type):
+    def __init__(self, cls: type | str):
         super().__init__(f"Cyclic dependency detected: {_describe_service(cls)}.")
 
 
 class MissingTypeAnnotationException(DIException):
-    def __init__(self, param_name: str, cls: type):
+    # `owner` is the class or function that declared the parameter.
+    def __init__(self, param_name: str, owner: Any):
         super().__init__(
             f"Missing type annotation for parameter '{param_name}' "
-            f"in class '{cls.__name__}'."
+            f"in '{getattr(owner, '__name__', owner)}'."
         )
 
 

--- a/injex/planning.py
+++ b/injex/planning.py
@@ -25,15 +25,19 @@ class Named:
     name: str
 
 
+_INJECT_FLAG = "__injex_inject__"
+
+
 def inject(func: Callable[..., Any]) -> Callable[..., Any]:
-    func.__annotations__["_inject"] = True
+    """Mark a method for property injection (its return type is resolved and set
+    as an attribute). Kept off ``__annotations__`` so it never leaks into
+    ``get_type_hints``."""
+    setattr(func, _INJECT_FLAG, True)
     return func
 
 
 def is_injectable(func: Callable[..., Any]) -> bool:
-    return hasattr(func, "__annotations__") and func.__annotations__.get(
-        "_inject", False
-    )
+    return getattr(func, _INJECT_FLAG, False)
 
 
 @cache

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -126,8 +126,7 @@ class TestContainer(unittest.TestCase):
         with self.assertRaises(MissingTypeAnnotationException) as context:
             self.container.resolve(ServiceE)
         self.assertIn(
-            "Missing type annotation for parameter 'missing_annotation' "
-            "in class 'ServiceE'.",
+            "Missing type annotation for parameter 'missing_annotation' in 'ServiceE'.",
             str(context.exception),
         )
 


### PR DESCRIPTION
From a deep pre-launch audit. Small correctness/quality fixes:

- `aresolve()` resource guard printed the raw class repr (`<class '...'>`); now uses the clean name like every other error.
- `CyclicDependencyException` / `MissingTypeAnnotationException` were typed `cls: type` but receive forward-ref strings and (since `call()`) functions — widened to match reality, and the message reads "in 'X'" generically.
- `@inject` stored its marker in `func.__annotations__`, which leaked into `get_type_hints` (now that hints use `include_extras`); moved to a dedicated attribute.
- The lifestyle-validity check was copy-pasted in three methods; now one helper.

No behaviour change beyond the cleaner messages. mypy strict + ruff clean, 159 passed.