### PR TITLE
Audit fixes: site accuracy + integration coverage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,8 +65,7 @@ framework-sized dependency injection container.
 - [When Python manual wiring turns into copy-paste architecture](https://vshulcz.hashnode.dev/when-python-manual-wiring-turns-into-copy-paste-architecture)
 - [Where should dependency wiring live in a Python app?](https://vshulcz.hashnode.dev/where-should-dependency-wiring-live-in-a-python-app)
 - [Fast dependency injection in Python without a provider framework](https://dev.to/vshulcz/fast-dependency-injection-in-python-without-a-provider-framework-3dko)
-- [Injex 1.3.0 launch post on X](https://x.com/vshulcz_dev/status/2064249921570533567?s=20)
-- [Injex project thread on X](https://x.com/vshulcz_dev/status/2059720295536009683?s=20)
+- [Updates on X](https://x.com/vshulcz_dev)
 
 ## Project notes
 

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -60,7 +60,9 @@
               <tr><td><code>add_transient(interface, implementation=None, name=None)</code></td><td>Create a new instance on each resolve.</td></tr>
               <tr><td><code>add_scoped(interface, implementation=None, name=None)</code></td><td>Reuse one instance inside a scope.</td></tr>
               <tr><td><code>add_instance(interface, instance, name=None)</code></td><td>Register an already built object.</td></tr>
-              <tr><td><code>add_*_factory(interface, factory, name=None)</code></td><td>Use custom construction logic.</td></tr>
+              <tr><td><code>add_singleton_factory / add_transient_factory / add_scoped_factory(interface, factory, name=None)</code></td><td>Custom construction; a generator factory becomes a resource with teardown.</td></tr>
+              <tr><td><code>register / register_factory(interface, …, lifestyle="transient", name=None)</code></td><td>General forms the helpers wrap.</td></tr>
+              <tr><td><code>scan(*modules_or_iterables)</code></td><td>Register every <code>@injectable</code> class found.</td></tr>
             </tbody>
           </table>
         </div>
@@ -69,8 +71,15 @@
         <ul>
           <li><code>resolve(interface, name=None)</code> resolves one service.</li>
           <li><code>resolve_all(interface, name=None)</code> resolves registered implementations.</li>
-          <li><code>create_scope()</code> creates a request, job, or message lifetime.</li>
+          <li><code>call(func, **overrides)</code> calls a function with its annotated
+            parameters injected; <code>acall</code> is the async form.</li>
+          <li><code>create_scope()</code> creates a request, job, or message lifetime
+            (usable as a <code>with</code> block; finalizes scoped resources).</li>
         </ul>
+        <p>
+          To inject a named registration into a constructor, annotate it
+          <code>Annotated[T, Named("primary")]</code>.
+        </p>
 
         <h2>Overrides</h2>
         <pre><code>with container.override(PaymentGateway, instance=fake_gateway):
@@ -101,6 +110,24 @@
           <code>AsyncResolutionRequiredException</code> if the graph needs async work.
           See <a href="./async.html">async resolution</a>.
         </p>
+
+        <h2>Decorators and markers</h2>
+        <ul>
+          <li><code>@inject</code> — mark a method for property injection.</li>
+          <li><code>@injectable(lifestyle="transient", name=None, provides=None)</code> —
+            mark a class for <code>container.scan()</code>.</li>
+          <li><code>Named("name")</code> — inside <code>Annotated[T, Named("name")]</code>,
+            selects a named registration.</li>
+        </ul>
+
+        <h2>Integrations</h2>
+        <ul>
+          <li><code>injex.ext.fastapi</code>: <code>setup_injex(app, container)</code> +
+            <code>Provide(T)</code> — see
+            <a href="./fastapi-depends.html">FastAPI</a>. Install <code>injex[fastapi]</code>.</li>
+          <li><code>injex.ext.cli</code>: <code>Inject()</code> + <code>wire(container)</code>
+            for Typer/Click commands.</li>
+        </ul>
 
         <h2>Exceptions</h2>
         <p>

--- a/site/docs/fastapi-depends.html
+++ b/site/docs/fastapi-depends.html
@@ -110,6 +110,27 @@ services.register_user.execute("ada@example.com")</code></pre>
           service wiring.
         </p>
 
+        <h2 id="optional-integration">Optional integration</h2>
+        <p>
+          If you'd rather not write the lifespan/scope glue by hand, the optional
+          <code>injex.ext.fastapi</code> integration (install
+          <code>injex[fastapi]</code>) opens one scope per request, finalizes its
+          resources when the request ends, and provides a <code>Provide</code>
+          dependency:
+        </p>
+        <pre><code>from injex.ext.fastapi import Provide, setup_injex
+
+setup_injex(app, container)
+
+@app.post("/register")
+def register_user(email: str, use_case: RegisterUser = Provide(RegisterUser)) -> int:
+    return use_case.execute(email)</code></pre>
+        <p>
+          It is a thin adapter over <code>ascope()</code>; the container stays
+          framework-agnostic, so the same wiring still serves workers, CLIs, and
+          tests.
+        </p>
+
         <nav class="pager" aria-label="Next pages">
           <a href="./di-frameworks.html"><small>Next</small>DI framework comparison</a>
           <a href="./recipes.html"><small>Example</small>Application wiring recipes</a>

--- a/site/docs/recipes.html
+++ b/site/docs/recipes.html
@@ -70,8 +70,9 @@ container.assert_valid()
 
 app = FastAPI()
 
-def get_scope() -&gt; Scope:
-    return container.create_scope()
+def get_scope() -&gt; Iterator[Scope]:
+    with container.create_scope() as scope:  # finalizes scoped resources on exit
+        yield scope
 
 def get_register_user(scope: Scope = Depends(get_scope)) -&gt; RegisterUser:
     return scope.resolve(RegisterUser)
@@ -81,7 +82,9 @@ def create_user(use_case: RegisterUser = Depends(get_register_user)):
     return use_case.execute()</code></pre>
         <p>
           Register request-owned objects as scoped services. Keep long-lived
-          clients as singletons.
+          clients as singletons. The optional
+          <a href="./fastapi-depends.html#optional-integration"><code>injex.ext.fastapi</code></a>
+          integration writes this scope-per-request glue for you.
         </p>
 
         <h2>Worker job scope</h2>
@@ -126,6 +129,16 @@ def main() -&gt; None:
     settings = Settings(api_url="https://api.example.com")
     container = build_container(settings)
     container.resolve(SyncUsersCommand).run()</code></pre>
+        <p>
+          With Typer or Click, <code>injex.ext.cli</code> injects the command object
+          so the framework only sees real CLI arguments:
+        </p>
+        <pre><code>from injex.ext.cli import Inject, wire
+
+@app.command()
+@wire(container)
+def sync_users(command: SyncUsersCommand = Inject()) -&gt; None:
+    command.run()</code></pre>
 
         <h2>Test override boundary</h2>
         <p>

--- a/site/index.html
+++ b/site/index.html
@@ -45,7 +45,7 @@
         "codeRepository": "https://github.com/vshulcz/injex",
         "programmingLanguage": "Python",
         "runtimePlatform": "Python 3.10, Python 3.11, Python 3.12, Python 3.13, Python 3.14",
-        "softwareVersion": "1.5.0",
+        "softwareVersion": "1.5.1",
         "applicationCategory": "DeveloperApplication",
         "description": "Tiny typed dependency injection for Python apps: explicit wiring, graph validation, zero runtime dependencies, and fast repeated resolves.",
         "keywords": "python dependency injection, python di container, FastAPI service wiring, Typer dependency injection, clean architecture Python, dependency injection benchmark",
@@ -270,7 +270,8 @@ service = container.resolve(Service)</code></pre>
           <span class="card-icon">★</span>
           <h3>Async, first-class</h3>
           <p><code>aresolve()</code> / <code>ascope()</code> await async factories
-            and async-resource lifecycles, on par with sync speed.</p>
+            and manage async-resource lifecycles; a fully-sync graph awaited this
+            way resolves at the sync fast-path speed.</p>
         </article>
         <article>
           <span class="card-icon">★</span>
@@ -389,15 +390,10 @@ service = container.resolve(Service)</code></pre>
             <strong>Fast dependency injection without a provider framework</strong>
             <small>The 1.3.0 article: boundary, benchmark, and trade-offs.</small>
           </a>
-          <a href="https://x.com/vshulcz_dev/status/2064249921570533567?s=20">
+          <a href="https://x.com/vshulcz_dev">
             <span>X</span>
-            <strong>Injex 1.3.0 launch post</strong>
-            <small>Release notes and benchmark snapshot for social sharing.</small>
-          </a>
-          <a href="https://x.com/vshulcz_dev/status/2059720295536009683?s=20">
-            <span>X</span>
-            <strong>Injex project thread</strong>
-            <small>The short thread about explicit typed wiring in Python.</small>
+            <strong>Updates on X</strong>
+            <small>Release notes and notes on explicit typed wiring in Python.</small>
           </a>
         </div>
       </section>


### PR DESCRIPTION
From the audit. Site + docs index only.

- `softwareVersion` 1.5.0 → 1.5.1 (matches PyPI).
- Replaced two fabricated-looking `x.com/.../status/<id>` links (README docs index + homepage) with the real profile — dead launch links are a trust hit.
- Qualified the homepage "async on par with sync speed" claim to the benchmarked case (fully-sync graph awaited).
- **Closed the homepage→docs gap:** the site advertised `injex.ext.fastapi`/`injex.ext.cli`/`scan`/`call` but the doc pages didn't show them. Expanded `api.html` (scan, register, call/acall, decorators, integrations), added an Optional-integration section to `fastapi-depends.html`, and pointed the FastAPI/CLI recipes at the ext modules.
- Fixed the FastAPI recipe to close its per-request scope.

Site/docs only.