### PR TITLE
Harden CI: cross-OS, link/spell checks, Scorecard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,10 @@ jobs:
       - name: Check relative links
         uses: lycheeverse/lychee-action@v2
         with:
-          # --offline checks local files only (no flaky network). The /injex/...
-          # links are root-relative for the deployed GitHub Pages site and only
-          # resolve there, so exclude that prefix.
-          args: '--offline --no-progress --exclude "^/injex/" README.md CHANGELOG.md CONTRIBUTING.md ROADMAP.md docs site'
+          # --offline checks local files only (no flaky network). 404.html uses
+          # root-relative /injex/ links that only resolve on the deployed Pages
+          # site, which lychee can't build offline — skip just that file.
+          args: "--offline --no-progress --exclude-path site/404.html README.md CHANGELOG.md CONTRIBUTING.md ROADMAP.md docs site"
           fail: true
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,10 @@ jobs:
       - name: Check relative links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--offline --no-progress README.md CHANGELOG.md CONTRIBUTING.md ROADMAP.md docs site"
+          # --offline checks local files only (no flaky network). The /injex/...
+          # links are root-relative for the deployed GitHub Pages site and only
+          # resolve there, so exclude that prefix.
+          args: '--offline --no-progress --exclude "^/injex/" README.md CHANGELOG.md CONTRIBUTING.md ROADMAP.md docs site'
           fail: true
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   UV_FROZEN: "1"
 
@@ -43,6 +47,9 @@ jobs:
       - name: Run format checks
         run: uv run ruff format --check .
 
+      - name: Spell check
+        run: uv run --with codespell codespell .
+
   type-check:
     name: Type Checking
     runs-on: ubuntu-latest
@@ -70,11 +77,25 @@ jobs:
         run: uv run --no-sync mypy injex tests
 
   test:
-    name: Run Tests
-    runs-on: ubuntu-latest
+    name: Tests (${{ matrix.os }} / ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          # Cross-OS smoke on the oldest and newest supported Pythons —
+          # threading, asyncio, the exec-compiled creators, and file-backed
+          # resources all need to behave the same off Linux.
+          - os: macos-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.13"
 
     steps:
       - name: Checkout code
@@ -99,7 +120,7 @@ jobs:
       - name: Upload coverage file
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-${{ matrix.python-version }}
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage.xml
 
   fastapi:
@@ -128,6 +149,20 @@ jobs:
       - name: Run FastAPI integration tests
         run: uv run --no-sync pytest tests/test_ext_fastapi.py --no-cov
 
+  links:
+    name: Link Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check relative links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--offline --no-progress README.md CHANGELOG.md CONTRIBUTING.md ROADMAP.md docs site"
+          fail: true
+
   coverage:
     name: Upload Coverage to Codecov
     runs-on: ubuntu-latest
@@ -140,7 +175,7 @@ jobs:
       - name: Download coverage files
         uses: actions/download-artifact@v8
         with:
-          name: coverage-3.10
+          name: coverage-ubuntu-latest-3.10
 
       - name: Upload coverage to Codecov
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "27 4 * * 1"
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coverage](https://codecov.io/gh/vshulcz/injex/branch/main/graph/badge.svg)](https://codecov.io/gh/vshulcz/injex)
 [![Python](https://img.shields.io/badge/python-3.10%E2%80%933.14-blue)](https://pypi.org/project/injex/)
 [![License](https://img.shields.io/github/license/vshulcz/injex.svg)](./LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/vshulcz/injex/badge)](https://scorecard.dev/viewer/?uri=github.com/vshulcz/injex)
 
 **Tiny typed dependency injection for Python that catches missing dependencies and
 cycles _before_ your app starts — with zero runtime dependencies.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ injex = ["py.typed"]
 [tool.setuptools.packages.find]
 include = ["injex*"]
 
+[tool.codespell]
+skip = "./.git,./.venv,./dist,./uv.lock,./site/assets,*.svg,*.png,*.ico"
+ignore-words-list = "injex"
+
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]
 


### PR DESCRIPTION
CI was Linux-only with no concurrency control. This strengthens it for a library that leans on threading, asyncio, exec-compiled creators, and file-backed resources.

- **Cross-OS matrix:** tests now also run on macOS and Windows (Python 3.10 and 3.13) next to the full Linux matrix; `fail-fast: false` so one platform doesn't mask another.
- **Concurrency:** superseded runs on the same ref are cancelled.
- **Link check:** offline lychee over README/docs/site catches broken relative links (no flaky external requests).
- **Spell check:** codespell step (config in pyproject; repo is currently clean).
- **OpenSSF Scorecard:** new workflow publishing SARIF to the Security tab + a README badge.

No source changes.