### PR TITLE
Fix Scorecard action version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
`ossf/scorecard-action` has no floating `v2` tag; pin to `v2.4.3` (the latest release). Dependabot's github-actions group will keep it current.