### PR TITLE
CI check command, graph(), better validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project uses semantic versioning.
 
 ## [Unreleased]
 
+### Added
+
+- `python -m injex check module:container` — validate a container's graph in CI
+  without constructing anything; exits non-zero on any error. Also installed as
+  the `injex` console script. Accepts a `Container` or a zero-arg factory.
+- `container.graph(fmt="text")` renders the dependency graph as text, Mermaid, or
+  DOT (zero dependencies, no rendering), marking unregistered dependencies.
+- `injex.testing.overrides(container, {Interface: instance, ...})` applies several
+  test overrides at once and restores them on exit.
+
+### Changed
+
+- Validation errors now show the full resolution path (`Handler -> UseCase ->
+  Repo -> dep`) and suggest the nearest registered name on a likely typo. The
+  same missing binding reached by several routes is reported once.
+
+### Fixed
+
+- Under `from __future__ import annotations`, a single unresolvable annotation no
+  longer makes `validate()` and `resolve()` disagree: resolve() now matches
+  string annotations by registered name the same way validate() does, so a
+  validated graph resolves.
+
 ## [1.6.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,25 @@ container.assert_valid()            # or raise with all of them at once
 ```
 
 That makes it safe to run as a startup guard even when real constructors open
-sockets or files.
+sockets or files. Errors name the full path to the break and suggest a near
+match:
+
+```
+Repo: Dependency 'session' is not registered: Session.
+Resolution path: Handler -> UseCase -> Repo -> session. Did you mean Sesion?
+```
+
+Run the same check in CI, no test harness needed:
+
+```bash
+python -m injex check myapp.bootstrap:container   # exits non-zero on any error
+```
+
+And print the wiring to read or diff it (`text`, `mermaid`, or `dot`, zero deps):
+
+```python
+print(container.graph("mermaid"))
+```
 
 ## Lifetimes, overrides, scopes
 
@@ -261,7 +279,8 @@ with the modern full-featured ones — **dishka** and **Wireup** — see
 | `call(fn, **overrides)` | Invoke a function with its dependencies injected. |
 | `create_scope()` | Start a request/job lifetime (`with` finalizes scoped resources). |
 | `override(T, ...)` | Temporarily replace a dependency in tests. |
-| `validate()` / `assert_valid()` | Check wiring before startup. |
+| `validate()` / `assert_valid()` | Check wiring before startup (also `python -m injex check module:container` for CI). |
+| `graph(fmt="text")` | Render the wiring as text, Mermaid, or DOT. |
 | `aresolve(T)` / `ascope()` / `acall(fn)` / `aclose()` | Async equivalents (await factories, async resources). |
 | `close()` | Finalize singleton resources at shutdown. |
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -68,6 +68,63 @@ container)` plus `use_case: RegisterUser = Provide(RegisterUser)`. See
 See also: [`examples/fastapi_app.py`](../examples/fastapi_app.py) and
 [`examples/fastapi_ext.py`](../examples/fastapi_ext.py).
 
+## One database session per request
+
+Register the session as a scoped async-generator factory. Injex opens it the
+first time it is resolved in a scope, hands the *same* session to everything in
+that request, and finalizes it (LIFO, via the standard library's
+`AsyncExitStack`) when the scope exits. No middleware, no contextvars.
+
+```python
+from collections.abc import AsyncIterator
+
+from injex import Container
+
+
+class Settings:
+    dsn = "postgresql://localhost/app"
+
+
+class Session:
+    def __init__(self, dsn: str):
+        self.dsn = dsn
+
+    async def close(self) -> None: ...
+
+
+class UserRepository:
+    def __init__(self, session: Session):  # receives the request's session
+        self.session = session
+
+
+async def open_session(settings: Settings) -> AsyncIterator[Session]:
+    session = Session(settings.dsn)
+    try:
+        yield session
+    finally:
+        await session.close()  # runs when the request scope exits
+
+
+container = Container()
+container.add_instance(Settings, Settings())
+container.add_scoped_factory(Session, open_session)
+container.add_transient(UserRepository)
+container.assert_valid()
+
+
+async def handle_request() -> None:
+    async with container.ascope() as scope:
+        repo_a = await scope.aresolve(UserRepository)
+        repo_b = await scope.aresolve(UserRepository)
+        assert repo_a.session is repo_b.session  # one session for the request
+    # session.close() has run here; the next scope opens a fresh session
+```
+
+Under FastAPI the request scope is opened for you by `injex.ext.fastapi`, so a
+route that asks for `UserRepository` (or the `Session` directly) gets one bound
+to that request and released when it returns. Use `add_scoped_factory` with a
+plain generator when the driver is synchronous — teardown works the same.
+
 ## Worker job scope
 
 Workers usually have two lifetimes: process lifetime and job lifetime. Keep

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -4,6 +4,73 @@ These recipes show where to keep container calls in common application shapes.
 They use small examples on purpose: the important part is the boundary, not the
 domain model.
 
+## One container, many entry points
+
+The point of a container is that the *same* validated graph backs every way the
+app runs — HTTP, a worker, a CLI, tests — so wiring never drifts between them.
+Build it once, validate it once, resolve from it everywhere.
+
+```python
+# bootstrap.py — the one composition root
+from injex import Container
+
+
+def build_container() -> Container:
+    container = Container()
+    container.add_singleton(Settings)
+    container.add_singleton(Database)
+    container.add_scoped(UnitOfWork)
+    container.add_transient(RegisterUser)
+    container.assert_valid()  # fail fast, in every entry point and in CI
+    return container
+```
+
+```python
+# api.py
+from injex.ext.fastapi import Provide, setup_injex
+
+from bootstrap import build_container
+
+app = FastAPI()
+setup_injex(app, build_container())
+
+
+@app.post("/users")
+async def create(use_case: RegisterUser = Provide(RegisterUser)):
+    return use_case.execute(...)
+```
+
+```python
+# worker.py
+from bootstrap import build_container
+
+container = build_container()
+
+
+def handle_job(payload) -> None:
+    with container.create_scope() as scope:  # one scope per job
+        scope.resolve(RegisterUser).execute(payload)
+```
+
+```python
+# cli.py
+from injex.ext.cli import Inject, wire
+
+from bootstrap import build_container
+
+
+@app.command()
+@wire(build_container())
+def register(email: str, use_case: RegisterUser = Inject()):
+    use_case.execute(email)
+```
+
+Each entry point opens its own scope — a request, a job, a command — over one
+shared graph. `python -m injex check bootstrap:build_container` validates that
+graph in CI, so a dependency added for the API but forgotten in the worker fails
+the build instead of a 3 a.m. page. The sections below show each entry point in
+more detail.
+
 ## FastAPI composition root
 
 Keep the container at application startup. Request handlers should receive use

--- a/injex/__main__.py
+++ b/injex/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/injex/__main__.py
+++ b/injex/__main__.py
@@ -1,4 +1,4 @@
 from .cli import main
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/injex/cli.py
+++ b/injex/cli.py
@@ -1,0 +1,83 @@
+"""Command line entry point: ``python -m injex check <module>:<attr>``.
+
+Validates a container's dependency graph in CI without constructing anything,
+exiting non-zero when the graph is incomplete. Standard library only."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import sys
+from typing import Any
+
+from .container import Container
+
+
+def _load_container(spec: str) -> Container:
+    if ":" not in spec:
+        raise SystemExit(
+            f"error: target must be 'module:attribute', got {spec!r} "
+            "(e.g. 'myapp.bootstrap:container')"
+        )
+    module_name, _, attr = spec.partition(":")
+
+    # Make the current directory importable so a project's own module resolves
+    # whether invoked as `python -m injex` or via the `injex` console script.
+    cwd = os.getcwd()
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise SystemExit(f"error: could not import '{module_name}': {exc}") from exc
+
+    try:
+        target: Any = getattr(module, attr)
+    except AttributeError:
+        raise SystemExit(f"error: '{module_name}' has no attribute '{attr}'") from None
+
+    # Accept a Container directly, or a zero-argument factory that returns one.
+    if callable(target) and not isinstance(target, Container):
+        target = target()
+    if not isinstance(target, Container):
+        raise SystemExit(
+            f"error: '{spec}' is not a Container (got {type(target).__name__})"
+        )
+    return target
+
+
+def _check(spec: str) -> int:
+    container = _load_container(spec)
+    errors = container.validate()
+    if not errors:
+        print(f"OK: {spec} — dependency graph is valid")
+        return 0
+    print(f"FAIL: {spec} — {len(errors)} error(s):", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="injex",
+        description="Validate an Injex container's dependency graph.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    check = subcommands.add_parser(
+        "check",
+        help="Validate a container without constructing services (for CI).",
+    )
+    check.add_argument(
+        "target",
+        help="Container to validate, as 'module:attribute' "
+        "(e.g. 'myapp.bootstrap:container').",
+    )
+    args = parser.parse_args(argv)
+    return _check(args.target)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/injex/cli.py
+++ b/injex/cli.py
@@ -25,7 +25,7 @@ def _load_container(spec: str) -> Container:
     # Make the current directory importable so a project's own module resolves
     # whether invoked as `python -m injex` or via the `injex` console script.
     cwd = os.getcwd()
-    if cwd not in sys.path:
+    if cwd not in sys.path:  # pragma: no cover - depends on how python was invoked
         sys.path.insert(0, cwd)
 
     try:
@@ -79,5 +79,5 @@ def main(argv: list[str] | None = None) -> int:
     return _check(args.target)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())

--- a/injex/container.py
+++ b/injex/container.py
@@ -22,6 +22,8 @@ from .errors import (
     ValidationError,
     _describe_service,
 )
+from .graph import GraphNode
+from .graph import render as _render_graph
 from .planning import (
     _cached_injected_properties,
     _cached_property_dependencies,
@@ -500,6 +502,62 @@ class Container:
         errors = self.validate()
         if errors:
             raise ContainerValidationException(errors)
+
+    def graph(self, fmt: str = "text") -> str:
+        """Render the registered dependency graph without constructing anything.
+
+        ``fmt`` is "text" (indented adjacency list), "mermaid", or "dot". Returns
+        a string to print, commit as a snapshot, or paste into a Mermaid/Graphviz
+        renderer — zero dependencies. Dependencies that are not registered are
+        marked so gaps in the graph are visible at a glance."""
+        nodes: list[GraphNode] = []
+        for (interface, name), registrations in self._registrations.items():
+            for registration in registrations:
+                label = _describe_service(interface)
+                if name is not None:
+                    label += f" named '{name}'"
+
+                if (
+                    registration.kind == RegistrationType.SERVICE
+                    and registration.implementation is not None
+                ):
+                    service_plan = self._get_service_plan(registration)
+                    plan_deps = (
+                        *service_plan.dependencies,
+                        *service_plan.property_dependencies,
+                    )
+                elif (
+                    registration.kind == RegistrationType.FACTORY
+                    and registration.factory is not None
+                ):
+                    plan_deps = self._get_factory_plan(registration).dependencies
+                else:
+                    plan_deps = ()
+
+                deps: list[tuple[str, bool, bool]] = []
+                for dep in plan_deps:
+                    if (
+                        dep.inject_container
+                        or dep.dependency_type is inspect.Parameter.empty
+                    ):
+                        continue
+                    dep_name = dep.dependency_key[1] if dep.dependency_key else None
+                    base_key = self._get_validation_key(dep.dependency_type)
+                    registered = (base_key[0], dep_name) in self._registrations
+                    dep_label = _describe_service(dep.dependency_type)
+                    if dep_name is not None:
+                        dep_label += f" named '{dep_name}'"
+                    deps.append(
+                        (dep_label, registered, dep.is_optional or dep.has_default)
+                    )
+
+                kind = (
+                    registration.lifestyle
+                    if registration.kind != RegistrationType.INSTANCE
+                    else "instance"
+                )
+                nodes.append(GraphNode(label, kind, tuple(deps)))
+        return _render_graph(nodes, fmt)
 
     def _resolve_in_scope(
         self, interface: type | str, scope: Scope, name: str | None = None

--- a/injex/container.py
+++ b/injex/container.py
@@ -1257,6 +1257,15 @@ class Container:
         registrations = None
         if dependency_key is not None:
             registrations = self._registrations.get(dependency_key)
+            if not registrations and isinstance(dependency_key[0], str):
+                # A string annotation (e.g. an unresolved forward reference under
+                # `from __future__ import annotations`) resolves by matching a
+                # registered class by name — the same rule validate() uses, so
+                # resolve() and validate() never disagree about it.
+                canonical = self._get_validation_key(dependency_key[0])
+                if canonical[0] is not dependency_key[0]:
+                    dependency_key = (canonical[0], dependency_key[1])
+                    registrations = self._registrations.get(dependency_key)
         if registrations:
             registration = registrations[0]
             key = dependency_key

--- a/injex/container.py
+++ b/injex/container.py
@@ -1,4 +1,5 @@
 import asyncio
+import difflib
 import inspect
 import threading
 from collections.abc import Callable
@@ -481,13 +482,14 @@ class Container:
     def validate(self) -> list[ValidationError]:
         """Validate registered dependency graphs without creating service instances."""
         errors: list[ValidationError] = []
-        seen: set[str] = set()
+        seen: set[tuple[Any, str | None, str]] = set()
         for key, registrations in self._registrations.items():
             for registration in registrations:
                 for error in self._validate_registration(key, registration, []):
                     # A shared dependency is reached from several roots; report
-                    # each distinct problem once.
-                    marker = str(error)
+                    # each distinct problem once (ignoring the path detail, so
+                    # the same missing binding isn't listed once per route).
+                    marker = (error.service, error.name, error.message)
                     if marker not in seen:
                         seen.add(marker)
                         errors.append(error)
@@ -673,11 +675,14 @@ class Container:
             described = _describe_service(dependency_type)
             if dep_name is not None:
                 described += f" named '{dep_name}'"
+            trail = self._describe_path(path, dependency_name)
+            hint = self._nearest_registration_hint(dependency_type)
             return [
                 ValidationError(
                     source_key[0],
                     source_key[1],
                     f"Dependency '{dependency_name}' is not registered: {described}.",
+                    detail=f"{trail}{hint}",
                 )
             ]
 
@@ -697,6 +702,27 @@ class Container:
                 ):
                     return (registered_service, None)
         return (dependency_type, None)
+
+    @staticmethod
+    def _describe_path(path: list[tuple[type | str, str | None]], leaf: str) -> str:
+        """Render the chain of owners that leads to a missing dependency, so the
+        error points at where in the graph the break is (Handler -> Repo -> ...)."""
+        if not path:
+            return ""
+        chain = " -> ".join(_describe_service(item[0]) for item in path)
+        return f" Resolution path: {chain} -> {leaf}."
+
+    def _nearest_registration_hint(self, dependency_type: Any) -> str:
+        """Suggest the closest registered service name for a likely typo/misname."""
+        wanted = _describe_service(dependency_type)
+        registered = {
+            _describe_service(service)
+            for service, name in self._registrations
+            if name is None
+        }
+        registered.discard(wanted)
+        close = difflib.get_close_matches(wanted, list(registered), n=1, cutoff=0.6)
+        return f" Did you mean {close[0]}?" if close else ""
 
     def _get_fast_creator(
         self,

--- a/injex/errors.py
+++ b/injex/errors.py
@@ -63,12 +63,16 @@ class ValidationError:
     service: type | str
     name: str | None
     message: str
+    # Extra context (resolution path, suggestions) rendered after the message
+    # but excluded from de-duplication, so the same problem reached by several
+    # paths is reported once.
+    detail: str = ""
 
     def __str__(self) -> str:
         service = _describe_service(self.service)
         if self.name is not None:
             service += f" named '{self.name}'"
-        return f"{service}: {self.message}"
+        return f"{service}: {self.message}{self.detail}"
 
 
 class ContainerValidationException(DIException):

--- a/injex/graph.py
+++ b/injex/graph.py
@@ -1,0 +1,82 @@
+"""Render a container's dependency graph as text, Mermaid, or Graphviz DOT.
+
+Pure string emission, zero dependencies — print it, commit it, or paste it into
+a Mermaid/Graphviz renderer. The container builds the node list; these functions
+only format it."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GraphNode:
+    label: str
+    kind: str  # lifestyle ("singleton"/"transient"/"scoped") or "instance"
+    # (dependency label, is it registered, is it optional/defaulted)
+    deps: tuple[tuple[str, bool, bool], ...]
+
+
+def _dep_suffix(registered: bool, optional: bool) -> str:
+    if registered:
+        return ""
+    return " (optional, unregistered)" if optional else " (unregistered)"
+
+
+def to_text(nodes: list[GraphNode]) -> str:
+    lines: list[str] = []
+    for node in nodes:
+        lines.append(f"{node.label} [{node.kind}]")
+        for label, registered, optional in node.deps:
+            lines.append(f"    -> {label}{_dep_suffix(registered, optional)}")
+    return "\n".join(lines)
+
+
+def _ids(nodes: list[GraphNode]) -> dict[str, str]:
+    ids: dict[str, str] = {}
+    for node in nodes:
+        ids.setdefault(node.label, f"n{len(ids)}")
+        for label, _registered, _optional in node.deps:
+            ids.setdefault(label, f"n{len(ids)}")
+    return ids
+
+
+def to_mermaid(nodes: list[GraphNode]) -> str:
+    ids = _ids(nodes)
+    lines = ["flowchart TD"]
+    for label, node_id in ids.items():
+        lines.append(f'    {node_id}["{label}"]')
+    for node in nodes:
+        for label, registered, _optional in node.deps:
+            arrow = "-->" if registered else "-.->"
+            lines.append(f"    {ids[node.label]} {arrow} {ids[label]}")
+    return "\n".join(lines)
+
+
+def to_dot(nodes: list[GraphNode]) -> str:
+    lines = ["digraph injex {", "    rankdir=LR;"]
+    seen: set[str] = set()
+    for node in nodes:
+        for label in (node.label, *(dep[0] for dep in node.deps)):
+            if label not in seen:
+                seen.add(label)
+                lines.append(f'    "{label}";')
+    for node in nodes:
+        for label, registered, _optional in node.deps:
+            style = "" if registered else " [style=dashed]"
+            lines.append(f'    "{node.label}" -> "{label}"{style};')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+_RENDERERS = {"text": to_text, "mermaid": to_mermaid, "dot": to_dot}
+
+
+def render(nodes: list[GraphNode], fmt: str) -> str:
+    try:
+        renderer = _RENDERERS[fmt]
+    except KeyError:
+        raise ValueError(
+            f"unknown graph format {fmt!r}; use 'text', 'mermaid', or 'dot'"
+        ) from None
+    return renderer(nodes)

--- a/injex/testing.py
+++ b/injex/testing.py
@@ -1,0 +1,37 @@
+"""Test helpers. Opt-in: ``from injex.testing import overrides``.
+
+``container.override(...)`` already swaps one binding and restores it on exit,
+in sync, async, scoped and nested contexts. ``overrides`` applies several at
+once with a single restore, which reads cleanly inside a pytest fixture::
+
+    import pytest
+    from injex.testing import overrides
+
+    @pytest.fixture
+    def container():
+        return build_container()  # your application's container
+
+    def test_registration(container):
+        with overrides(container, {Mailer: FakeMailer(), Clock: FrozenClock()}):
+            container.resolve(RegisterUser).execute("ada@example.com")
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import ExitStack, contextmanager
+from typing import Any
+
+from .container import Container
+
+
+@contextmanager
+def overrides(
+    container: Container, mapping: Mapping[Any, Any] | None = None
+) -> Iterator[Container]:
+    """Temporarily replace several bindings with instances, restoring every one
+    on exit (LIFO). ``mapping`` maps an interface to the instance to inject."""
+    with ExitStack() as stack:
+        for interface, instance in (mapping or {}).items():
+            stack.enter_context(container.override(interface, instance=instance))
+        yield container

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ include = ["injex*"]
 
 [tool.codespell]
 skip = "./.git,./.venv,./dist,./uv.lock,./site/assets,*.svg,*.png,*.ico"
-ignore-words-list = "injex"
+# "sesion"/"databse" appear only as intentional typo examples for the near-name hint.
+ignore-words-list = "injex,sesion,databse"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = []
 [project.optional-dependencies]
 fastapi = ["fastapi>=0.100"]
 
+[project.scripts]
+injex = "injex.cli:main"
+
 [tool.uv]
 # fastapi/httpx are intentionally NOT here: the type-check and FastAPI jobs add
 # them per-job (they pull pydantic-core, which has no wheel for Python 3.14 yet).

--- a/site/docs/api.html
+++ b/site/docs/api.html
@@ -87,8 +87,10 @@
 
         <h2>Validation</h2>
         <ul>
-          <li><code>validate()</code> returns validation errors.</li>
+          <li><code>validate()</code> returns validation errors (with the full resolution path and a nearest-name hint).</li>
           <li><code>assert_valid()</code> raises <code>ContainerValidationException</code> if validation fails.</li>
+          <li><code>python -m injex check module:container</code> validates in CI and exits non-zero on any error.</li>
+          <li><code>graph(fmt="text")</code> renders the wiring as text, Mermaid, or DOT.</li>
         </ul>
 
         <h2>Async</h2>

--- a/site/docs/validation.html
+++ b/site/docs/validation.html
@@ -77,6 +77,23 @@ if errors:
           service constructors still happen when the service is resolved.
         </p>
 
+        <h2>Check it in CI</h2>
+        <p>
+          Run the same check as a build step — no test harness, exits non-zero on
+          any error:
+        </p>
+        <pre><code>python -m injex check myapp.bootstrap:container</code></pre>
+        <p>A missing binding names the full path to the break and suggests a near match:</p>
+        <pre><code>Repo: Dependency 'session' is not registered: Session.
+Resolution path: Handler -&gt; UseCase -&gt; Repo -&gt; session. Did you mean Sesion?</code></pre>
+
+        <h2>See the graph</h2>
+        <p>
+          Render the wiring as text, Mermaid, or DOT to read or diff it — zero
+          dependencies, nothing constructed:
+        </p>
+        <pre><code>print(container.graph("mermaid"))</code></pre>
+
         <nav class="pager" aria-label="Next pages">
           <a href="./getting-started.html"><small>Previous</small>Getting started</a>
           <a href="./comparison.html"><small>Next</small>Comparison</a>

--- a/site/index.html
+++ b/site/index.html
@@ -130,6 +130,10 @@
             <span>Check the dependency graph before constructing services.</span>
           </div>
           <div class="metric-card">
+            <strong>Check in CI</strong>
+            <span><code>python -m injex check</code> fails the build on a broken graph.</span>
+          </div>
+          <div class="metric-card">
             <strong>Override</strong>
             <span>Swap external dependencies in a precise test scope.</span>
           </div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -18,6 +18,12 @@ Key facts:
 - Features: typed constructor injection, factories, instances, named
   registrations (`Annotated[T, Named(...)]`), optional dependencies, property
   injection, test overrides, graph validation
+- CI gate: `python -m injex check module:container` validates the graph and exits
+  non-zero on any error (also the `injex` console script)
+- Graph inspection: `container.graph(fmt="text"|"mermaid"|"dot")` renders the
+  wiring as a string (zero dependencies)
+- Validation errors show the full resolution path and suggest the nearest
+  registered name
 - Resources: generator factories (sync and async) with teardown finalized on
   scope exit or `close()` / `aclose()`
 - Async: `aresolve()`, `ascope()`, `acall()`, `aclose()`

--- a/tests/_cli_app.py
+++ b/tests/_cli_app.py
@@ -1,0 +1,35 @@
+"""Fixtures for the CLI tests: a valid container, a broken one, a factory, and
+a non-container attribute."""
+
+from injex import Container
+
+
+class Config: ...
+
+
+class Client:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+
+class Missing: ...
+
+
+class Broken:
+    def __init__(self, missing: Missing) -> None:  # Missing is never registered
+        self.missing = missing
+
+
+container = Container()
+container.add_singleton(Config)
+container.add_singleton(Client)
+
+broken = Container()
+broken.add_transient(Broken)
+
+
+def make_container() -> Container:
+    return container
+
+
+not_a_container = 42

--- a/tests/_future_annotations_app.py
+++ b/tests/_future_annotations_app.py
@@ -1,0 +1,28 @@
+"""Fixtures defined under ``from __future__ import annotations`` so every
+annotation is a string that must be resolved at registration time."""
+
+from __future__ import annotations
+
+
+class Database: ...
+
+
+class Repo:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+
+class Service:
+    def __init__(self, repo: Repo) -> None:
+        self.repo = repo
+
+
+class Mailer: ...
+
+
+class Handler:
+    # 'Ghost' is never defined: get_type_hints() raises for the whole __init__,
+    # which must NOT stop 'mailer' (a good, registered dependency) from
+    # resolving, and must be reported the same way by validate() and resolve().
+    def __init__(self, mailer: Mailer, ghost: Ghost) -> None:  # type: ignore[name-defined]  # noqa: F821
+        self.mailer = mailer

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -265,3 +265,38 @@ def test_async_singleton_built_once_under_concurrent_resolve():
         assert len({id(r) for r in results}) == 1  # all got the same instance
 
     asyncio.run(main())
+
+
+def test_scoped_session_shared_across_transitive_deps_then_closed():
+    # The "one DB session per request" recipe: one session for the whole scope,
+    # shared by every dependency that needs it, finalized on scope exit.
+    events = []
+
+    class Session:
+        async def close(self) -> None:
+            events.append("close")
+
+    class Repo:
+        def __init__(self, session: Session) -> None:
+            self.session = session
+
+    async def open_session():
+        session = Session()
+        events.append("open")
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    async def main():
+        c = Container()
+        c.add_scoped_factory(Session, open_session)
+        c.add_transient(Repo)
+        async with c.ascope() as scope:
+            first = await scope.aresolve(Repo)
+            second = await scope.aresolve(Repo)
+            assert first.session is second.session
+            assert events == ["open"]  # opened once, not per resolve
+        assert events == ["open", "close"]  # closed when the scope exits
+
+    asyncio.run(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,40 @@
+"""`python -m injex check module:container` — the CI gate around validate()."""
+
+import pytest
+
+from injex.cli import main
+
+
+def test_check_valid_container_exits_zero(capsys):
+    assert main(["check", "tests._cli_app:container"]) == 0
+    out = capsys.readouterr().out
+    assert "valid" in out
+
+
+def test_check_accepts_a_factory(capsys):
+    assert main(["check", "tests._cli_app:make_container"]) == 0
+    assert "valid" in capsys.readouterr().out
+
+
+def test_check_broken_container_exits_nonzero(capsys):
+    assert main(["check", "tests._cli_app:broken"]) == 1
+    err = capsys.readouterr().err
+    assert "Missing" in err  # names the missing binding
+
+
+def test_check_reports_bad_target_spec():
+    with pytest.raises(SystemExit) as excinfo:
+        main(["check", "no_colon_here"])
+    assert "module:attribute" in str(excinfo.value)
+
+
+def test_check_reports_missing_attribute():
+    with pytest.raises(SystemExit) as excinfo:
+        main(["check", "tests._cli_app:nope"])
+    assert "no attribute" in str(excinfo.value)
+
+
+def test_check_rejects_non_container():
+    with pytest.raises(SystemExit) as excinfo:
+        main(["check", "tests._cli_app:not_a_container"])
+    assert "not a Container" in str(excinfo.value)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,12 @@ def test_check_reports_bad_target_spec():
     assert "module:attribute" in str(excinfo.value)
 
 
+def test_check_reports_import_failure():
+    with pytest.raises(SystemExit) as excinfo:
+        main(["check", "tests._no_such_module_here:container"])
+    assert "could not import" in str(excinfo.value)
+
+
 def test_check_reports_missing_attribute():
     with pytest.raises(SystemExit) as excinfo:
         main(["check", "tests._cli_app:nope"])

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,52 @@
+"""Constructor defaults and partial construction — the most common "why won't
+this wire" friction. A parameter with a default is not a missing dependency, and
+call() can construct a class with some arguments supplied by hand."""
+
+from injex import Container
+
+
+def test_resolve_uses_constructor_default_when_dependency_is_unregistered():
+    class Cache: ...
+
+    class Service:
+        def __init__(self, cache: "Cache | None" = None, retries: int = 3):
+            self.cache = cache
+            self.retries = retries
+
+    c = Container()
+    c.add_transient(Service)
+
+    assert c.validate() == []  # a default is not a missing dependency
+    service = c.resolve(Service)
+    assert service.cache is None
+    assert service.retries == 3
+
+
+def test_registered_dependency_wins_over_a_default():
+    class Cache: ...
+
+    class Service:
+        def __init__(self, cache: Cache | None = None):
+            self.cache = cache
+
+    c = Container()
+    c.add_singleton(Cache)
+    c.add_transient(Service)
+
+    assert isinstance(c.resolve(Service).cache, Cache)
+
+
+def test_call_constructs_a_class_with_partial_kwargs():
+    class DB: ...
+
+    class Repo:
+        def __init__(self, db: DB, table: str):
+            self.db = db
+            self.table = table
+
+    c = Container()
+    c.add_singleton(DB)
+
+    repo = c.call(Repo, table="users")
+    assert isinstance(repo.db, DB)
+    assert repo.table == "users"

--- a/tests/test_error_messages.py
+++ b/tests/test_error_messages.py
@@ -59,3 +59,50 @@ def test_validate_does_not_duplicate_shared_dependency_errors():
     errors = c.validate()
     messages = [str(e) for e in errors]
     assert len(messages) == len(set(messages))  # no duplicates
+
+
+def test_validation_error_shows_full_resolution_path():
+    class Session:
+        pass
+
+    class Store:
+        def __init__(self, session: Session):
+            self.session = session
+
+    class UseCase:
+        def __init__(self, store: Store):
+            self.store = store
+
+    class Handler:
+        def __init__(self, use_case: UseCase):
+            self.use_case = use_case
+
+    c = Container()
+    c.add_transient(Handler)
+    c.add_transient(UseCase)
+    c.add_transient(Store)  # Session never registered
+
+    errors = c.validate()
+    text = "\n".join(str(e) for e in errors)
+    assert "Handler -> UseCase -> Store -> session" in text
+    # the same missing binding reached by several routes is reported once
+    assert sum("not registered: Session" in str(e) for e in errors) == 1
+
+
+def test_validation_error_suggests_nearest_registered_name():
+    class Database:
+        pass
+
+    class Databse:  # deliberate typo, registered instead of Database
+        pass
+
+    class Service:
+        def __init__(self, db: Database):
+            self.db = db
+
+    c = Container()
+    c.add_transient(Service)
+    c.add_singleton(Databse)
+
+    errors = c.validate()
+    assert any("Did you mean Databse?" in str(e) for e in errors)

--- a/tests/test_future_annotations.py
+++ b/tests/test_future_annotations.py
@@ -1,0 +1,45 @@
+"""`from __future__ import annotations` (PEP 563) turns every annotation into a
+string. Injection must still work, and — crucially for the validate-before-start
+guarantee — validate() and resolve() must agree even when one annotation in a
+signature cannot be resolved."""
+
+import pytest
+
+from injex import Container
+from injex.errors import ServiceNotRegisteredException
+from tests import _future_annotations_app as app
+
+
+def test_resolves_a_string_annotated_graph():
+    container = Container()
+    container.add_singleton(app.Database)
+    container.add_singleton(app.Repo)
+    container.add_transient(app.Service)
+
+    assert container.validate() == []
+    service = container.resolve(app.Service)
+    assert isinstance(service.repo, app.Repo)
+    assert isinstance(service.repo.db, app.Database)
+
+
+def test_one_unresolvable_annotation_does_not_break_its_siblings():
+    """A single unresolvable annotation (here a name that only exists as a
+    forward reference) must not stop the other, registered dependency from
+    resolving, and validate()/resolve() must point at the same problem."""
+    container = Container()
+    container.add_singleton(app.Mailer)
+    container.add_transient(app.Handler)
+
+    errors = container.validate()
+    messages = [error.message for error in errors]
+
+    # The unresolvable dependency is reported...
+    assert any("Ghost" in message for message in messages)
+    # ...and the good, registered sibling is NOT falsely flagged.
+    assert all("Mailer" not in message for message in messages)
+
+    # resolve() fails on the SAME dependency validate() flagged, not on the
+    # good sibling — the two never disagree.
+    with pytest.raises(ServiceNotRegisteredException) as excinfo:
+        container.resolve(app.Handler)
+    assert "Ghost" in str(excinfo.value)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -61,6 +61,25 @@ def test_instance_registration_is_labelled():
     assert "Config [instance]" in c.graph()
 
 
+def test_graph_includes_factory_dependencies():
+    class Settings: ...
+
+    class Client:
+        def __init__(self, settings: Settings) -> None:
+            self.settings = settings
+
+    def make_client(settings: Settings) -> Client:
+        return Client(settings)
+
+    c = Container()
+    c.add_singleton(Settings)
+    c.add_singleton_factory(Client, make_client)
+
+    text = c.graph()
+    assert "Client [singleton]" in text
+    assert "-> Settings" in text
+
+
 def test_unknown_format_raises():
     with pytest.raises(ValueError, match="unknown graph format"):
         _container().graph("svg")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,73 @@
+"""container.graph() renders the wiring as text / Mermaid / DOT without building
+anything, marking unregistered dependencies."""
+
+import pytest
+
+from injex import Container
+
+
+class Config: ...
+
+
+class Session: ...
+
+
+class Repo:
+    def __init__(self, cfg: Config, session: Session) -> None:  # Session unregistered
+        self.cfg = cfg
+        self.session = session
+
+
+class Service:
+    def __init__(self, repo: Repo) -> None:
+        self.repo = repo
+
+
+def _container() -> Container:
+    c = Container()
+    c.add_singleton(Config)
+    c.add_transient(Repo)
+    c.add_transient(Service)
+    return c
+
+
+def test_text_graph_shows_edges_lifestyles_and_gaps():
+    text = _container().graph()
+    assert "Config [singleton]" in text
+    assert "Repo [transient]" in text
+    assert "-> Config" in text
+    assert "-> Session (unregistered)" in text
+    assert "-> Repo" in text
+
+
+def test_mermaid_graph_uses_solid_and_dashed_edges():
+    mermaid = _container().graph("mermaid")
+    assert mermaid.startswith("flowchart TD")
+    assert "-->" in mermaid  # registered edge
+    assert "-.->" in mermaid  # unregistered edge (Session)
+
+
+def test_dot_graph_is_a_digraph_with_dashed_gaps():
+    dot = _container().graph("dot")
+    assert dot.startswith("digraph injex {")
+    assert '"Repo" -> "Config";' in dot
+    assert "[style=dashed]" in dot  # unregistered Session
+    assert dot.rstrip().endswith("}")
+
+
+def test_instance_registration_is_labelled():
+    c = Container()
+    c.add_instance(Config, Config())
+    assert "Config [instance]" in c.graph()
+
+
+def test_unknown_format_raises():
+    with pytest.raises(ValueError, match="unknown graph format"):
+        _container().graph("svg")
+
+
+def test_empty_container_graphs_are_empty_but_valid():
+    c = Container()
+    assert c.graph() == ""
+    assert c.graph("mermaid") == "flowchart TD"
+    assert c.graph("dot").startswith("digraph injex {")

--- a/tests/test_override_everywhere.py
+++ b/tests/test_override_everywhere.py
@@ -1,0 +1,99 @@
+"""override() must work the same in sync, nested, scoped and async resolution,
+and injex.testing.overrides applies several at once."""
+
+import asyncio
+
+from injex import Container
+from injex.testing import overrides
+
+
+class Mailer:
+    def send(self) -> str:
+        return "real"
+
+
+class Fake:
+    def send(self) -> str:
+        return "fake"
+
+
+class UseCase:
+    def __init__(self, mailer: Mailer) -> None:
+        self.mailer = mailer
+
+
+def _container() -> Container:
+    c = Container()
+    c.add_singleton(Mailer)
+    c.add_transient(UseCase)
+    return c
+
+
+def test_override_restores_afterwards():
+    c = _container()
+    assert c.resolve(UseCase).mailer.send() == "real"
+    with c.override(Mailer, instance=Fake()):
+        assert c.resolve(UseCase).mailer.send() == "fake"
+    assert c.resolve(UseCase).mailer.send() == "real"
+
+
+def test_nested_overrides_stack_and_unwind():
+    c = _container()
+
+    class Fake2:
+        def send(self) -> str:
+            return "fake2"
+
+    with c.override(Mailer, instance=Fake()):
+        with c.override(Mailer, instance=Fake2()):
+            assert c.resolve(UseCase).mailer.send() == "fake2"
+        assert c.resolve(UseCase).mailer.send() == "fake"
+    assert c.resolve(UseCase).mailer.send() == "real"
+
+
+def test_override_applies_inside_a_scope():
+    c = _container()
+    with c.override(Mailer, instance=Fake()), c.create_scope() as scope:
+        assert scope.resolve(UseCase).mailer.send() == "fake"
+
+
+def test_override_applies_to_async_resolution():
+    async def go() -> tuple[str, str]:
+        c = _container()
+        with c.override(Mailer, instance=Fake()):
+            during = (await c.aresolve(UseCase)).mailer.send()
+        after = (await c.aresolve(UseCase)).mailer.send()
+        return during, after
+
+    during, after = asyncio.run(go())
+    assert during == "fake"
+    assert after == "real"
+
+
+def test_overrides_helper_applies_several_and_restores():
+    class Clock:
+        def now(self) -> str:
+            return "real-time"
+
+    class FrozenClock:
+        def now(self) -> str:
+            return "frozen"
+
+    class App:
+        def __init__(self, mailer: Mailer, clock: Clock) -> None:
+            self.mailer = mailer
+            self.clock = clock
+
+    c = Container()
+    c.add_singleton(Mailer)
+    c.add_singleton(Clock)
+    c.add_transient(App)
+
+    with overrides(c, {Mailer: Fake(), Clock: FrozenClock()}):
+        app = c.resolve(App)
+        assert app.mailer.send() == "fake"
+        assert app.clock.now() == "frozen"
+
+    restored = c.resolve(App)
+    assert restored.mailer.send() == "real"
+    assert restored.clock.now() == "real-time"

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -34,3 +34,9 @@ if TYPE_CHECKING:
         scope = c.create_scope()
         assert_type(c.resolve("Foo"), Any)
         assert_type(scope.resolve("Foo"), Any)
+
+    # The async overloads recover the same concrete types.
+    async def _aresolve_infers_concrete_types(c: Container) -> None:
+        assert_type(await c.aresolve(Foo), Foo)
+        async with c.ascope() as scope:
+            assert_type(await scope.aresolve(Foo), Foo)


### PR DESCRIPTION
Tooling round from the voice-of-customer research — everything here sharpens the validate-before-startup story, no new runtime deps.

- `python -m injex check module:container` validates a container's graph in CI and exits non-zero on any error (also the `injex` console script).
- `container.graph(fmt="text"|"mermaid"|"dot")` prints the wiring to read or diff.
- Validation errors now show the full resolution path (`Handler -> UseCase -> Repo -> dep`) and suggest the nearest registered name.
- `injex.testing.overrides(...)` applies several test overrides at once.
- Fix: under `from __future__ import annotations`, one unresolvable hint made validate() and resolve() disagree. resolve() now matches string annotations by name like validate() does, so a validated graph resolves.

178 tests, docs and site updated. Next release is 1.7.0 (adds features, semver-minor).