### PR TITLE
Release 1.8.1: clearer Inject() annotation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project uses semantic versioning.
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-28
+
+### Fixed
+
+- `inject` / `ainject` (`injex.ext.tasks`) and `wire` (`injex.ext.cli`) now raise
+  a clear error when an `Inject()` parameter has no type annotation, instead of
+  failing later with an opaque "'_empty' is not registered" message.
+
 ## [1.8.0] - 2026-07-27
 
 ### Added

--- a/injex/ext/cli.py
+++ b/injex/ext/cli.py
@@ -53,6 +53,13 @@ def wire(container: "Container") -> Callable[[Callable[..., T]], Callable[..., T
             for param in signature.parameters.values()
             if param.default is not _INJECT
         ]
+        for param in signature.parameters.values():
+            if param.default is _INJECT and param.annotation is inspect.Parameter.empty:
+                raise TypeError(
+                    f"Parameter '{param.name}' of {func.__name__}() is marked "
+                    "Inject() but has no type annotation; add one so injex knows "
+                    "what to resolve."
+                )
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> T:

--- a/injex/ext/tasks.py
+++ b/injex/ext/tasks.py
@@ -38,6 +38,12 @@ def _split_parameters(
     signature = inspect.signature(func)
     injected = [p for p in signature.parameters.values() if p.default is _INJECT]
     visible = [p for p in signature.parameters.values() if p.default is not _INJECT]
+    for param in injected:
+        if param.annotation is inspect.Parameter.empty:
+            raise TypeError(
+                f"Parameter '{param.name}' of {func.__name__}() is marked Inject() "
+                "but has no type annotation; add one so injex knows what to resolve."
+            )
     return signature, injected, visible
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "injex"
-version = "1.8.0"
+version = "1.8.1"
 authors = [{name = "vshulcz", email = "vshulcz@gmail.com"}]
 description = "Tiny typed dependency injection container for Python"
 readme = "README.md"

--- a/tests/test_ext_cli.py
+++ b/tests/test_ext_cli.py
@@ -3,10 +3,21 @@
 import inspect
 
 import click
+import pytest
 from click.testing import CliRunner
 
 from injex import Container
 from injex.ext.cli import Inject, wire
+
+
+def test_wire_requires_a_type_annotation():
+    container = Container()
+
+    with pytest.raises(TypeError, match="no type annotation"):
+
+        @wire(container)
+        def command(name: str, service=Inject()):  # service has no annotation
+            return service
 
 
 class Greeter:

--- a/tests/test_ext_tasks.py
+++ b/tests/test_ext_tasks.py
@@ -4,9 +4,21 @@ handler functions, framework-agnostic (Celery, arq, aiogram, ...)."""
 import asyncio
 import inspect
 
+import pytest
+
 from injex import Container
 from injex.ext.cli import Inject
 from injex.ext.tasks import ainject, inject
+
+
+def test_inject_requires_a_type_annotation():
+    container = Container()
+
+    with pytest.raises(TypeError, match="no type annotation"):
+
+        @inject(container)
+        def task(order_id: int, thing=Inject()):  # thing has no annotation
+            return thing
 
 
 class Orders:

--- a/uv.lock
+++ b/uv.lock
@@ -694,7 +694,7 @@ wheels = [
 
 [[package]]
 name = "injex"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
inject/ainject/wire raise a readable error when an Inject() parameter has no type annotation, instead of failing later with an opaque message. Found while verifying every integration end-to-end against 1.8.0 (all pass). Version bump + changelog.